### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 # HAL 9000
 
+[![Run in Smithery](https://smithery.ai/badge/skills/vinta)](https://smithery.ai/skills?ns=vinta&utm_source=github&utm_medium=badge)
+
+
 [![](https://img.shields.io/badge/made%20with-%e2%9d%a4-ff69b4.svg?style=flat-square)](https://vinta.ws/code/)
 
 Automatically setup a productive development environment with Ansible on macOS.


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/vinta)](https://smithery.ai/skills?ns=vinta&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.