### PR TITLE
Security hardening for hal CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install lint format typecheck update-hooks run-hooks scan-secrets run-gitleaks run-detect-secrets audit-detect-secrets-report hal-completion
+.PHONY: help install lint format typecheck test update-hooks run-hooks scan-secrets run-gitleaks run-detect-secrets audit-detect-secrets-report hal-completion
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -26,6 +26,9 @@ format: ## Auto-format and fix lint issues
 
 typecheck: ## Run ty type checker
 	uv run ty check bin/hal
+
+test: ## Run tests
+	uv run pytest tests/ -v
 
 update-hooks: ## Update pre-commit hooks to latest versions
 	uv run pre-commit autoupdate

--- a/bin/hal
+++ b/bin/hal
@@ -163,7 +163,8 @@ class HAL9000:
             self._hal_says("Now open a new shell to active your dev environment")
 
     def link(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
-        filepath = str(Path.cwd() / namespace.filename)
+        filepath = str((Path.cwd() / namespace.filename).resolve())
+        self._validate_path(filepath)
 
         # Get relative path from home directory
         home = str(Path.home())
@@ -173,26 +174,26 @@ class HAL9000:
         dest_path = str(Path(Setting.DOTFILES_ROOT) / relative_path)
         dest_dir = str(Path(dest_path).parent)
 
-        # Create directory if it doesn't exist
         if dest_dir != Setting.DOTFILES_ROOT:
-            self._run(f"mkdir -p {shlex.quote(dest_dir)}")
+            Path(dest_dir).mkdir(parents=True, exist_ok=True)
 
-        if self._run(f"mv {shlex.quote(filepath)} {shlex.quote(dest_path)}") == 0:
-            ln_src = dest_path
-            ln_dest = filepath
-            self._run(f"ln -sf {shlex.quote(ln_src)} {shlex.quote(ln_dest)}")
+        shutil.move(filepath, dest_path)
+        self._hal_says(f"mv {filepath} -> {dest_path}")
+        ln_src = dest_path
+        ln_dest = filepath
+        self._run(f"ln -sf {shlex.quote(ln_src)} {shlex.quote(ln_dest)}")
 
-            template_src = dest_path.replace(Setting.REPO_ROOT, "{{REPO_ROOT}}")
-            template_dest = filepath.replace(home, "{{HOME}}")
+        template_src = dest_path.replace(Setting.REPO_ROOT, "{{REPO_ROOT}}")
+        template_dest = filepath.replace(home, "{{HOME}}")
 
-            ln_dict = self.dotfiles.find_by_key("src", template_src, "links")
-            if ln_dict:
-                ln_dict["dest"] = template_dest
-            else:
-                self.dotfiles.data["links"].append({"dest": template_dest, "src": template_src})
+        ln_dict = self.dotfiles.find_by_key("src", template_src, "links")
+        if ln_dict:
+            ln_dict["dest"] = template_dest
+        else:
+            self.dotfiles.data["links"].append({"dest": template_dest, "src": template_src})
 
-            self.dotfiles.save()
-            self.dotfiles.show()
+        self.dotfiles.save()
+        self.dotfiles.show()
 
     def unlink(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
         relative_path = namespace.filename.removeprefix("~/")
@@ -223,7 +224,8 @@ class HAL9000:
         self.dotfiles.show()
 
     def copy(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
-        filepath = str(Path.cwd() / namespace.filename)
+        filepath = str((Path.cwd() / namespace.filename).resolve())
+        self._validate_path(filepath)
 
         # Get relative path from home directory
         home = str(Path.home())
@@ -233,22 +235,23 @@ class HAL9000:
         dest_path = str(Path(Setting.DOTFILES_ROOT) / relative_path)
         dest_dir = str(Path(dest_path).parent)
 
-        # Create directory if it doesn't exist
         if dest_dir != Setting.DOTFILES_ROOT:
-            self._run(f"mkdir -p {shlex.quote(dest_dir)}")
+            Path(dest_dir).mkdir(parents=True, exist_ok=True)
 
-        if self._run(f"cp -f {shlex.quote(filepath)} {shlex.quote(dest_path)}") == 0:
-            template_src = dest_path.replace(Setting.REPO_ROOT, "{{REPO_ROOT}}")
-            template_dest = filepath.replace(home, "{{HOME}}")
+        shutil.copy2(filepath, dest_path)
+        self._hal_says(f"cp {filepath} -> {dest_path}")
 
-            cp_dict = self.dotfiles.find_by_key("src", template_src, "copies")
-            if cp_dict:
-                cp_dict["dest"] = template_dest
-            else:
-                self.dotfiles.data["copies"].append({"dest": template_dest, "src": template_src})
+        template_src = dest_path.replace(Setting.REPO_ROOT, "{{REPO_ROOT}}")
+        template_dest = filepath.replace(home, "{{HOME}}")
 
-            self.dotfiles.save()
-            self.dotfiles.show()
+        cp_dict = self.dotfiles.find_by_key("src", template_src, "copies")
+        if cp_dict:
+            cp_dict["dest"] = template_dest
+        else:
+            self.dotfiles.data["copies"].append({"dest": template_dest, "src": template_src})
+
+        self.dotfiles.save()
+        self.dotfiles.show()
 
     def _sync_links(self, link: dict[str, str]) -> None:
         src = self._expand_template(link["src"])

--- a/bin/hal
+++ b/bin/hal
@@ -157,7 +157,7 @@ class HAL9000:
         os.chdir(str(Path(Setting.REPO_ROOT) / "playbooks"))
         command = "ansible-playbook site.yml -v"
         if extra_args:
-            command = " ".join([command, *extra_args])
+            command = " ".join([command, *(shlex.quote(arg) for arg in extra_args)])
         returncode = self._run(command)
         if returncode == 0:
             self._hal_says("Now open a new shell to active your dev environment")

--- a/bin/hal
+++ b/bin/hal
@@ -305,6 +305,10 @@ class HAL9000:
             sys.exit(0)
 
         namespace, extra_args = self.parser.parse_known_args()
+
+        if extra_args and namespace.func != self.update:
+            self.parser.parse_args()  # Will error with usage message on unrecognized args
+
         namespace.func(namespace, extra_args)
 
 

--- a/bin/hal
+++ b/bin/hal
@@ -104,8 +104,17 @@ class HAL9000:
     def _hal_says(self, text: str) -> None:
         print(f"HAL: {text}")
 
+    def _validate_path(self, path: str) -> None:
+        resolved = str(Path(path).resolve())
+        allowed_prefixes = (str(Path.home()), Setting.REPO_ROOT)
+        if not resolved.startswith(allowed_prefixes):
+            self._hal_says(f"I'm sorry, Dave. I'm afraid I can't do that: {resolved}")
+            sys.exit(1)
+
     def _expand_template(self, path: str) -> str:
-        return path.replace("{{HOME}}", str(Path.home())).replace("{{REPO_ROOT}}", Setting.REPO_ROOT)
+        expanded = path.replace("{{HOME}}", str(Path.home())).replace("{{REPO_ROOT}}", Setting.REPO_ROOT)
+        self._validate_path(expanded)
+        return expanded
 
     def _run(self, command: str, *, shell: bool = True, verbose: bool = True) -> int:
         if verbose:

--- a/bin/open-the-pod-bay-doors
+++ b/bin/open-the-pod-bay-doors
@@ -28,22 +28,22 @@ fi
 
 REPO_REMOTE=https://github.com/vinta/hal-9000.git
 REPO_ROOT=/usr/local/hal-9000
-if [ ! -d $REPO_ROOT/.git/ ]; then
+if [ ! -d "$REPO_ROOT"/.git/ ]; then
     printf "\n"
     printf "Checkout the GitHub repo...\n"
-    sudo git clone $REPO_REMOTE $REPO_ROOT
-    sudo chown -R "$USER":wheel $REPO_ROOT
+    sudo git clone "$REPO_REMOTE" "$REPO_ROOT"
+    sudo chown -R "$USER":wheel "$REPO_ROOT"
 else
     printf "\n"
     printf "Pull the GitHub repo...\n"
-    cd $REPO_ROOT
+    cd "$REPO_ROOT"
     git fetch
     git pull
 fi
 
 printf "\n"
 printf "Run ansible-playbook (will require your sudo password)...\n"
-cd $REPO_ROOT/playbooks
+cd "$REPO_ROOT"/playbooks
 ansible-playbook site.yml -v "$@"
 
-source $REPO_ROOT/playbooks/roles/basic/files/hal_profile.sh
+source "$REPO_ROOT"/playbooks/roles/basic/files/hal_profile.sh

--- a/bin/open-the-pod-bay-doors
+++ b/bin/open-the-pod-bay-doors
@@ -28,7 +28,7 @@ fi
 
 REPO_REMOTE=https://github.com/vinta/hal-9000.git
 REPO_ROOT=/usr/local/hal-9000
-if [ ! -d "$REPO_ROOT"/.git/ ]; then
+if [ ! -d "$REPO_ROOT/.git/" ]; then
     printf "\n"
     printf "Checkout the GitHub repo...\n"
     sudo git clone "$REPO_REMOTE" "$REPO_ROOT"
@@ -43,7 +43,7 @@ fi
 
 printf "\n"
 printf "Run ansible-playbook (will require your sudo password)...\n"
-cd "$REPO_ROOT"/playbooks
+cd "$REPO_ROOT/playbooks"
 ansible-playbook site.yml -v "$@"
 
-source "$REPO_ROOT"/playbooks/roles/basic/files/hal_profile.sh
+source "$REPO_ROOT/playbooks/roles/basic/files/hal_profile.sh"

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,4 +1,3 @@
 [defaults]
 inventory = hosts
 interpreter_python = auto_silent
-host_key_checking = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,12 @@ Repository = "https://github.com/vinta/hal-9000"
 
 [dependency-groups]
 dev = [
+    { include-group = "test" },
     { include-group = "lint" },
     { include-group = "audit" },
     "argcomplete>=3.6.3",
-    "pytest>=8.0.0",
 ]
+test = ["pytest>=9.0.2"]
 lint = ["ansible-lint>=26.1.1", "ruff>=0.15.2", "ty>=0.0.18"]
 audit = ["detect-secrets>=1.5.0", "pip-audit>=2.10.0", "pre-commit>=4.5.1"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,5 +62,9 @@ include = ["scripts", "dotfiles/.claude/statusline"]
 [tool.ty.terminal]
 error-on-warning = true
 
+[tool.ty.rules]
+possibly-unresolved-reference = "error"
+unused-ignore-comment = "error"
+
 [tool.ty.environment]
 python-version = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,13 @@ ignore = [
     "T20",    # print statements (CLI tools)
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "ANN",    # type annotations not needed in tests
+    "S101",   # assert is the standard for pytest
+    "SLF001", # testing private methods is intentional
+]
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
     { include-group = "lint" },
     { include-group = "audit" },
     "argcomplete>=3.6.3",
+    "pytest>=8.0.0",
 ]
 lint = ["ansible-lint>=26.1.1", "ruff>=0.15.2", "ty>=0.0.18"]
 audit = ["detect-secrets>=1.5.0", "pip-audit>=2.10.0", "pre-commit>=4.5.1"]

--- a/scripts/generate-completion.py
+++ b/scripts/generate-completion.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
+import importlib.machinery
+import importlib.util
 import sys
 from pathlib import Path
-from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-sys.path.insert(0, str(REPO_ROOT))
-
 hal_path = REPO_ROOT / "bin" / "hal"
-hal_content = hal_path.read_text()
-hal_content = hal_content.replace("__file__", repr(str(hal_path)))
+loader = importlib.machinery.SourceFileLoader("hal", str(hal_path))
+spec = importlib.util.spec_from_file_location("hal", hal_path, loader=loader)
+assert spec is not None  # noqa: S101 assert
+assert spec.loader is not None  # noqa: S101 assert
+module = importlib.util.module_from_spec(spec)
+sys.modules["hal"] = module
+spec.loader.exec_module(module)
 
-namespace: dict[str, Any] = {"__name__": "__hal_module__"}
-exec(hal_content, namespace)  # noqa: S102 exec-builtin
-
-HAL9000 = namespace["HAL9000"]
+HAL9000 = module.HAL9000  # type: ignore[attr-defined]
 hal = HAL9000()
 
 commands = []

--- a/tests/test_hal.py
+++ b/tests/test_hal.py
@@ -1,0 +1,1 @@
+"""Tests for bin/hal security hardening."""

--- a/tests/test_hal.py
+++ b/tests/test_hal.py
@@ -1,5 +1,3 @@
-"""Tests for bin/hal security hardening."""
-
 import argparse
 import importlib.machinery
 import importlib.util

--- a/tests/test_hal.py
+++ b/tests/test_hal.py
@@ -109,6 +109,7 @@ class TestFileOpsUseStdlib:
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
             patch("pathlib.Path.cwd", return_value=tmp_path),
             patch.object(hal_instance, "_validate_path"),
+            patch("shutil.move"),
         ):
             mock_dotfiles.find_by_key.return_value = None
             mock_dotfiles.data = {"links": [], "copies": []}
@@ -138,6 +139,7 @@ class TestFileOpsUseStdlib:
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
             patch("pathlib.Path.cwd", return_value=tmp_path),
             patch.object(hal_instance, "_validate_path"),
+            patch("shutil.copy2"),
         ):
             mock_dotfiles.find_by_key.return_value = None
             mock_dotfiles.data = {"links": [], "copies": []}

--- a/tests/test_hal.py
+++ b/tests/test_hal.py
@@ -1,1 +1,59 @@
 """Tests for bin/hal security hardening."""
+
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def hal_module():
+    """Import bin/hal as a module."""
+    hal_path = str(Path(__file__).resolve().parent.parent / "bin" / "hal")
+    spec = importlib.util.spec_from_loader(
+        "hal",
+        loader=importlib.machinery.SourceFileLoader("hal", hal_path),
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["hal"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hal_instance(hal_module):
+    """Create a HAL9000 instance."""
+    return hal_module.HAL9000()
+
+
+class TestValidatePath:
+    def test_valid_path_under_home(self, hal_instance):
+        home = str(Path.home())
+        path = f"{home}/.zshrc"
+        hal_instance._validate_path(path)
+
+    def test_valid_path_under_repo_root(self, hal_instance, hal_module):
+        path = f"{hal_module.Setting.REPO_ROOT}/dotfiles/.zshrc"
+        hal_instance._validate_path(path)
+
+    def test_path_traversal_outside_home(self, hal_instance):
+        home = str(Path.home())
+        path = f"{home}/../../etc/passwd"
+        with pytest.raises(SystemExit):
+            hal_instance._validate_path(path)
+
+    def test_path_to_etc(self, hal_instance):
+        with pytest.raises(SystemExit):
+            hal_instance._validate_path("/etc/crontab")
+
+    def test_path_traversal_in_template_expansion(self, hal_instance):
+        with pytest.raises(SystemExit):
+            hal_instance._expand_template("{{HOME}}/../../etc/crontab")
+
+    def test_normal_template_expansion(self, hal_instance):
+        result = hal_instance._expand_template("{{HOME}}/.zshrc")
+        assert result == f"{Path.home()}/.zshrc"

--- a/tests/test_hal.py
+++ b/tests/test_hal.py
@@ -157,3 +157,21 @@ class TestUserFilenameValidation:
         ns = argparse.Namespace(filename="../../../etc/passwd")
         with patch("pathlib.Path.cwd", return_value=tmp_path), pytest.raises(SystemExit):
             hal_instance.copy(ns)
+
+
+class TestArgParsing:
+    def test_unknown_args_rejected_for_link(self, hal_module):
+        """Non-update commands should reject unknown arguments."""
+        sys.argv = ["hal", "link", "--bogus", "somefile"]
+        hal = hal_module.HAL9000()
+        with pytest.raises(SystemExit) as exc_info:
+            hal.read_lips()
+        assert exc_info.value.code == 2  # noqa: PLR2004 argparse-usage-error
+
+    def test_unknown_args_rejected_for_sync(self, hal_module):
+        """sync should also reject unknown arguments."""
+        sys.argv = ["hal", "sync", "--unknown"]
+        hal = hal_module.HAL9000()
+        with pytest.raises(SystemExit) as exc_info:
+            hal.read_lips()
+        assert exc_info.value.code == 2  # noqa: PLR2004 argparse-usage-error

--- a/uv.lock
+++ b/uv.lock
@@ -515,6 +515,9 @@ lint = [
     { name = "ruff" },
     { name = "ty" },
 ]
+test = [
+    { name = "pytest" },
+]
 
 [package.metadata]
 
@@ -530,7 +533,7 @@ dev = [
     { name = "detect-secrets", specifier = ">=1.5.0" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
-    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.15.2" },
     { name = "ty", specifier = ">=0.0.18" },
 ]
@@ -539,6 +542,7 @@ lint = [
     { name = "ruff", specifier = ">=0.15.2" },
     { name = "ty", specifier = ">=0.0.18" },
 ]
+test = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "identify"

--- a/uv.lock
+++ b/uv.lock
@@ -506,6 +506,7 @@ dev = [
     { name = "detect-secrets" },
     { name = "pip-audit" },
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -529,6 +530,7 @@ dev = [
     { name = "detect-secrets", specifier = ">=1.5.0" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pytest", specifier = ">=8.0.0" },
     { name = "ruff", specifier = ">=0.15.2" },
     { name = "ty", specifier = ">=0.0.18" },
 ]
@@ -554,6 +556,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -865,6 +876,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -917,6 +937,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add path boundary validation to reject traversal attacks outside `$HOME` and `REPO_ROOT`
- Sanitize `extra_args` passed to `ansible-playbook` with `shlex.quote()` to prevent shell injection
- Replace shell-out file operations (`mv`, `cp`, `mkdir -p`) with stdlib equivalents (`shutil.move`, `shutil.copy2`, `Path.mkdir`)
- Reject unrecognized CLI arguments for non-`update` commands
- Replace `exec()` in `generate-completion.py` with `importlib` module loading
- Quote all shell variables in the bootstrap script
- Remove unnecessary `host_key_checking = False` from `ansible.cfg`
- Add pytest infrastructure and 13 tests covering all hardening changes

## Test plan

- [x] `make test` -- 13 tests pass
- [x] `make lint` / `make typecheck` -- verify no regressions
- [x] Manual smoke test: `hal sync`, `hal update --tags basic`
- [x] Verify `hal link` / `hal copy` still work with real files


🤖 Generated with [Claude Code](https://claude.com/claude-code)