### PR TITLE
feat(rules): add user-level .claude/rules for Python and TS/JS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,9 @@ tests/                                  # pytest tests
 ## Gotchas
 
 - **Python >=3.11** required. Package management via `uv`.
-- **Dotfile modes**: `link` (symlink) for small configs, `copy` for large or externally synced files. Manifest uses `{{HOME}}` and `{{REPO_ROOT}}` template variables.
-- **Skills are symlinked**: Always edit under `skills/`, never under `~/.claude/skills/`.
 - **`# noqa` format**: Always include the rule name: `# noqa: S603 subprocess-without-shell-equals-true`
+- **Dotfiles are the source of truth**: `dotfiles/.claude/` syncs to `~/.claude/` and `skills/` syncs to `~/.claude/skills/` via `hal_dotfiles.json`. Always edit under `dotfiles/` or `skills/`, never under `~/.claude/` directly. Update `hal_dotfiles.json` when adding new files, then run `hal sync`.
+- **Dotfile modes**: `link` (symlink) for small configs, `copy` for large or externally synced files. Manifest uses `{{HOME}}` and `{{REPO_ROOT}}` template variables.
 
 ## External Tool Documentation
 

--- a/dotfiles/.claude/rules/python.md
+++ b/dotfiles/.claude/rules/python.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "**/*.py"
+---
+
+# Python
+
+- Before adding a dependency, search PyPI or the web for the latest version
+- Pin exact dependency versions in `pyproject.toml` — no `>=`, `~=`, or `^` specifiers
+- Python >=3.11 — use modern syntax: `X | Y` unions, `match`/`case`, `tomllib`
+- Use `uv` for project and environment management
+- Use `ruff` for linting and formatting
+- Use `pytest` for testing
+  - `assert` is fine in tests but use `# noqa: S101 assert` elsewhere
+- Use `pathlib.Path` over `os.path`
+- `# noqa` comments must include the rule name: `# noqa: S603 subprocess-without-shell-equals-true`

--- a/dotfiles/.claude/rules/typescript-javascript.md
+++ b/dotfiles/.claude/rules/typescript-javascript.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "**/*.{ts,tsx}"
+  - "**/*.{js,jsx}"
+---
+
+# TypeScript / JavaScript
+
+- Before adding a dependency, search npm or the web for the latest version
+- Pin exact dependency versions in `package.json` — no `^` or `~` prefixes
+- Use `node:` prefix for Node.js built-in modules (e.g., `node:fs`, `node:path`)
+- Prefer `async`/`await` over `.then()` chains
+- Use template literals over string concatenation
+- Use optional chaining (`?.`) and nullish coalescing (`??`) over manual checks
+- Use strict equality (`===` / `!==`), never loose equality

--- a/dotfiles/hal_dotfiles.json
+++ b/dotfiles/hal_dotfiles.json
@@ -59,6 +59,10 @@
       "src": "{{REPO_ROOT}}/dotfiles/.claude/statusline/run.py"
     },
     {
+      "dest": "{{HOME}}/.claude/rules/",
+      "src": "{{REPO_ROOT}}/dotfiles/.claude/rules/"
+    },
+    {
       "dest": "{{HOME}}/.claude/skills/magi/",
       "src": "{{REPO_ROOT}}/skills/magi/"
     },


### PR DESCRIPTION
## Summary

- Add `dotfiles/.claude/rules/python.md` and `dotfiles/.claude/rules/typescript-javascript.md` as user-level language rules
- Rules use `paths` frontmatter so they only load when Claude touches matching files
- Symlinked to `~/.claude/rules/` via `hal_dotfiles.json` directory entry
- Update CLAUDE.md gotcha: `dotfiles/` is the source of truth for `~/.claude/`, not just skills

## Test plan

- [x] `hal sync` creates `~/.claude/rules` symlink pointing to `dotfiles/.claude/rules/`
- [ ] Rules appear in `/memory` output in a Claude Code session
- [ ] Python rules load only when working with `.py` files
- [ ] TS/JS rules load only when working with `.ts`/`.js` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)