### PR TITLE
chore: replace master branch references with main

### DIFF
--- a/.github/workflows/validate-ansible-playbooks.yml
+++ b/.github/workflows/validate-ansible-playbooks.yml
@@ -2,7 +2,7 @@ name: Validate Ansible Playbooks
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HAL 9000
 
-![HAL 9000](https://raw.githubusercontent.com/vinta/hal-9000/master/assets/hal-9000.jpg "HAL 9000")
+![HAL 9000](https://raw.githubusercontent.com/vinta/hal-9000/main/assets/hal-9000.jpg "HAL 9000")
 
 Opinionated macOS development environment automation that dominates your dev setup like cats rule the Internet.
 
@@ -24,7 +24,7 @@ Opinionated macOS development environment automation that dominates your dev set
 ## Bootstrap
 
 ```bash
-curl -L https://raw.githubusercontent.com/vinta/hal-9000/master/bin/open-the-pod-bay-doors | bash
+curl -L https://raw.githubusercontent.com/vinta/hal-9000/main/bin/open-the-pod-bay-doors | bash
 ```
 
 ## Components

--- a/dotfiles/.claude/statusline/README.md
+++ b/dotfiles/.claude/statusline/README.md
@@ -7,7 +7,7 @@ A custom [Claude Code statusline](https://code.claude.com/docs/en/statusline) th
 Download the script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/vinta/hal-9000/master/dotfiles/.claude/statusline/run.py \
+curl -fsSL https://raw.githubusercontent.com/vinta/hal-9000/main/dotfiles/.claude/statusline/run.py \
   -o ~/.claude/statusline/run.py \
   --create-dirs
 ```
@@ -25,4 +25,4 @@ Add to `~/.claude/settings.json`:
 
 ## Screenshots
 
-![Claude Code Statusline with English Grammar Check example](https://raw.githubusercontent.com/vinta/hal-9000/master/assets/claude-code-statusline-grammar-check.png)
+![Claude Code Statusline with English Grammar Check example](https://raw.githubusercontent.com/vinta/hal-9000/main/assets/claude-code-statusline-grammar-check.png)

--- a/plugins/hal-voice/README.md
+++ b/plugins/hal-voice/README.md
@@ -1,6 +1,6 @@
 # HAL Voice
 
-![HAL 9000](https://raw.githubusercontent.com/vinta/hal-9000/master/assets/hal-9000.jpg "HAL 9000")
+![HAL 9000](https://raw.githubusercontent.com/vinta/hal-9000/main/assets/hal-9000.jpg "HAL 9000")
 
 A Claude Code plugin that plays HAL 9000 voice clips on hook events: `SessionStart`, `SessionEnd`, `PreCompact`, `PermissionRequest`, `PreToolUse`, `PostToolUseFailure`, `SubagentStart`, `UserPromptSubmit`, and `Stop`. [Each event maps to a movie quote that fits the moment](manifest.json):
 

--- a/skills/magi-ex/README.md
+++ b/skills/magi-ex/README.md
@@ -1,6 +1,6 @@
 # The MAGI System EX
 
-![The MAGI System](https://raw.githubusercontent.com/vinta/hal-9000/master/assets/magi.webp "The MAGI System")
+![The MAGI System](https://raw.githubusercontent.com/vinta/hal-9000/main/assets/magi.webp "The MAGI System")
 
 ## Background
 

--- a/skills/magi/README.md
+++ b/skills/magi/README.md
@@ -1,6 +1,6 @@
 # The MAGI System
 
-![The MAGI System](https://raw.githubusercontent.com/vinta/hal-9000/master/assets/magi.webp "The MAGI System")
+![The MAGI System](https://raw.githubusercontent.com/vinta/hal-9000/main/assets/magi.webp "The MAGI System")
 
 ## Background
 

--- a/videos/hal-demo/src/scenes/BootstrapScene.tsx
+++ b/videos/hal-demo/src/scenes/BootstrapScene.tsx
@@ -10,7 +10,7 @@ import { loadFont } from "@remotion/google-fonts/SpaceMono";
 const { fontFamily } = loadFont();
 
 const BOOTSTRAP_COMMAND =
-  "curl -L https://raw.githubusercontent.com/vinta/hal-9000/master/bin/open-the-pod-bay-doors | bash";
+  "curl -L https://raw.githubusercontent.com/vinta/hal-9000/main/bin/open-the-pod-bay-doors | bash";
 
 const CHAR_FRAMES = 1.5;
 


### PR DESCRIPTION
## Summary

- Update all `raw.githubusercontent.com` URLs from `master` to `main` across README files and video source
- Update CI workflow branch trigger from `master` to `main`

Prepares for renaming the default branch. After merging, run:

```bash
git branch -m master main
git push -u origin main
gh repo edit --default-branch main
git push origin --delete master
```

## Test plan

- [ ] Verify CI triggers on the new branch name
- [ ] Verify raw.githubusercontent URLs resolve after branch rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)