### PR TITLE
Subagent statusline rows

### DIFF
--- a/dotfiles/.claude/settings.json
+++ b/dotfiles/.claude/settings.json
@@ -167,6 +167,10 @@
     "command": "python3 ~/.claude/statusline/hal-statusline.py",
     "refreshInterval": 1
   },
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "python3 ~/.claude/statusline/hal-statusline.py --subagents"
+  },
   "enabledPlugins": {
     "codex@openai-codex": true,
     "mattpocock-skills@mattpocock": true,

--- a/plugins/hal-statusline/hal-statusline.py
+++ b/plugins/hal-statusline/hal-statusline.py
@@ -71,6 +71,23 @@ class StatusLineData(TypedDict):
     context_window: NotRequired[ContextWindow]
 
 
+# https://code.claude.com/docs/en/statusline#subagent-status-lines
+class SubagentTask(TypedDict):
+    id: str
+    name: NotRequired[str]  # documented but absent from real payloads as of 2.1.220
+    description: str
+    label: str
+    tokenCount: int
+    model: NotRequired[str]  # omitted until the task's model is resolved
+    contextWindowSize: NotRequired[int]  # omitted together with model
+    effort: NotRequired[str | int]  # absent when the subagent inherits the session effort
+
+
+class SubagentStatusData(TypedDict):
+    columns: int
+    tasks: list[SubagentTask]
+
+
 class OllamaGenerateResponse(TypedDict):
     response: str
 
@@ -163,6 +180,39 @@ def basic_info(data: StatusLineData) -> None:
 
     separator = f"{RESET} {WHITE}·{RESET} {BLUE}"
     print(f"{WHITE}Current:{RESET} {BLUE}{separator.join(status_parts)}{RESET}")
+
+
+SEPARATOR_WIDTH = len(" · ")
+
+
+def subagent_row(task: SubagentTask, columns: int) -> str:
+    model = task["model"].removeprefix("claude-")
+    effort = task.get("effort")
+    model_part = f"{model} {effort}" if effort is not None else model
+    name = task.get("name")  # promised by the docs, but 2.1.220 payloads omit it
+    parts = [name, model_part] if name else [model_part]
+
+    ctx_pct = int(task["tokenCount"] / task["contextWindowSize"] * 100)
+    ctx_plain = f"Ctx {ctx_pct}%"
+    used = sum(len(part) for part in parts) + len(ctx_plain) + len(parts) * SEPARATOR_WIDTH
+    parts.append(f"{usage_color(ctx_pct)}{ctx_plain}{RESET}{BLUE}")
+
+    description = task["description"] or task["label"]
+    budget = columns - used - SEPARATOR_WIDTH
+    if len(description) > budget:
+        description = description[: budget - 1] + "…" if budget >= 2 else ""  # noqa: PLR2004 magic-value-comparison
+    if description:
+        parts.append(description)
+
+    separator = f"{RESET} {WHITE}·{RESET} {BLUE}"
+    return f"{BLUE}{separator.join(parts)}{RESET}"
+
+
+def subagent_status(data: SubagentStatusData) -> None:
+    for task in data["tasks"]:
+        if "model" not in task or "contextWindowSize" not in task:
+            continue
+        print(json.dumps({"id": task["id"], "content": subagent_row(task, data["columns"])}))
 
 
 NON_PROMPT_PREFIXES = (
@@ -450,6 +500,12 @@ def grammar_check(data: StatusLineData) -> None:
 def main() -> None:
     if len(sys.argv) >= 3 and sys.argv[1] == "--grammar-worker":  # noqa: PLR2004 magic-value-comparison
         run_grammar_worker(sys.argv[2])
+        return
+
+    if len(sys.argv) >= 2 and sys.argv[1] == "--subagents":  # noqa: PLR2004 magic-value-comparison
+        subagent_data: SubagentStatusData = json.load(sys.stdin)
+        logger.debug("subagents data=%s", json.dumps(subagent_data))
+        subagent_status(subagent_data)
         return
 
     data: StatusLineData = json.load(sys.stdin)

--- a/scripts/install-hal-statusline.sh
+++ b/scripts/install-hal-statusline.sh
@@ -38,6 +38,7 @@ if path.exists():
             d = {}
 
 d["statusLine"] = {"type": "command", "command": cmd, "refreshInterval": 1}
+d["subagentStatusLine"] = {"type": "command", "command": cmd + " --subagents"}
 
 with path.open("w") as f:
     json.dump(d, f, indent=2)

--- a/tests/plugins/test_hal_statusline.py
+++ b/tests/plugins/test_hal_statusline.py
@@ -126,3 +126,90 @@ class TestBasicInfo:
 
         out = strip_ansi(capsys.readouterr().out)
         assert out.startswith("Current: claude-fable-5 max · ")
+
+
+def make_task(**overrides):
+    task = {
+        "id": "task-1",
+        "name": "hal-skills-commit",
+        "type": "general-purpose",
+        "status": "running",
+        "description": "/hal-skills:commit all pending changes",
+        "label": "commit",
+        "startTime": 1754000000000,
+        "model": "claude-sonnet-5",
+        "effort": "high",
+        "contextWindowSize": 200000,
+        "tokenCount": 24000,
+        "tokenSamples": [],
+        "cwd": "/usr/local/hal-9000",
+    }
+    task.update(overrides)
+    return task
+
+
+def subagent_rows(capsys):
+    return [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+
+
+class TestSubagentStatus:
+    def test_full_task_renders_row(self, statusline, capsys):
+        statusline.subagent_status({"columns": 120, "tasks": [make_task()]})
+
+        rows = subagent_rows(capsys)
+        assert len(rows) == 1
+        assert rows[0]["id"] == "task-1"
+        assert strip_ansi(rows[0]["content"]) == "hal-skills-commit · sonnet-5 high · Ctx 12% · /hal-skills:commit all pending changes"
+
+    def test_inherited_effort_omitted(self, statusline, capsys):
+        task = make_task()
+        del task["effort"]
+
+        statusline.subagent_status({"columns": 120, "tasks": [task]})
+
+        rows = subagent_rows(capsys)
+        assert strip_ansi(rows[0]["content"]) == "hal-skills-commit · sonnet-5 · Ctx 12% · /hal-skills:commit all pending changes"
+
+    def test_unresolved_model_keeps_default_row(self, statusline, capsys):
+        task = make_task()
+        del task["model"]
+        del task["contextWindowSize"]
+
+        statusline.subagent_status({"columns": 120, "tasks": [task, make_task(id="task-2")]})
+
+        rows = subagent_rows(capsys)
+        assert [row["id"] for row in rows] == ["task-2"]
+
+    def test_description_truncates_to_columns(self, statusline, capsys):
+        statusline.subagent_status({"columns": 60, "tasks": [make_task()]})
+
+        content = strip_ansi(subagent_rows(capsys)[0]["content"])
+        assert content == "hal-skills-commit · sonnet-5 high · Ctx 12% · /hal-skills:c…"
+        assert len(content) == 60
+
+    def test_description_dropped_when_no_room(self, statusline, capsys):
+        statusline.subagent_status({"columns": 46, "tasks": [make_task()]})
+
+        content = strip_ansi(subagent_rows(capsys)[0]["content"])
+        assert content == "hal-skills-commit · sonnet-5 high · Ctx 12%"
+
+    def test_numeric_effort_budget_rendered_verbatim(self, statusline, capsys):
+        statusline.subagent_status({"columns": 120, "tasks": [make_task(effort=50000)]})
+
+        assert "sonnet-5 50000" in strip_ansi(subagent_rows(capsys)[0]["content"])
+
+    def test_empty_description_falls_back_to_label(self, statusline, capsys):
+        statusline.subagent_status({"columns": 120, "tasks": [make_task(description="")]})
+
+        content = strip_ansi(subagent_rows(capsys)[0]["content"])
+        assert content == "hal-skills-commit · sonnet-5 high · Ctx 12% · commit"
+
+    def test_task_without_name_renders_model_first(self, statusline, capsys):
+        task = make_task(model="claude-opus-5[1m]", contextWindowSize=1000000, tokenCount=28261, description="List repo files")
+        del task["name"]
+        del task["effort"]
+
+        statusline.subagent_status({"columns": 120, "tasks": [task]})
+
+        content = strip_ansi(subagent_rows(capsys)[0]["content"])
+        assert content == "opus-5[1m] · Ctx 2% · List repo files"


### PR DESCRIPTION
## What

Adds `subagentStatusLine` support to hal-statusline. A `--subagents` mode renders each agent panel row as `name · model effort · Ctx N% · description`, so you can see which model each subagent runs and how full its context is. Also wires the setting into `dotfiles/.claude/settings.json` and the installer script.

`name` and `effort` only show up when the payload has them. Skill forks send `name`, but subagents spawned with the Agent tool don't.

## Verification

`make test` (221 tests, 20 for statusline) and `make lint-python` pass. On Claude Code 2.1.272, a captured Explore subagent payload renders as `opus-5[1m] · Ctx 1% · List repo top-level files`.

## Related upstream issues

- https://github.com/anthropics/claude-code/issues/80560: named teammate rows never reach `subagentStatusLine`, so only Task subagent rows get the custom format
- https://github.com/anthropics/claude-code/issues/87716: same gap, `in_process_teammate` tasks are never passed to the command
- https://github.com/anthropics/claude-code/issues/88238: asks for the agent name in `tasks[]`, since `name` is missing from real payloads
- https://github.com/anthropics/claude-code/issues/80937: asks for `agentType` per task, so a row could show `Explore` or `general-purpose`
- https://github.com/anthropics/claude-code/issues/81320: `${CLAUDE_PLUGIN_ROOT}` doesn't resolve in plugin `settings.json`, so the plugin can't ship `subagentStatusLine` itself

Keeping this as a draft until we decide to ship the rows without names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
