### PR TITLE
refactor: restructure bin/hal.py and fix the dotfile bugs it surfaced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,6 @@ Pre-resolved IDs for the `find-docs` skill. Pass directly to `ctx7 docs`, skippi
 | -------------- | ------------------------------------------ |
 | ansible        | `/websites/ansible_projects_ansible`       |
 | ansible-lint   | `/ansible/ansible-lint`                    |
-| argcomplete    | `/kislyuk/argcomplete`                     |
 | betterleaks    | `/betterleaks/betterleaks`                 |
 | fnm            | `/schniz/fnm`                              |
 | github-actions | `/websites/github_en_actions`              |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,6 @@ Pre-resolved IDs for the `find-docs` skill. Pass directly to `ctx7 docs`, skippi
 | -------------- | ------------------------------------------ |
 | ansible        | `/websites/ansible_projects_ansible`       |
 | ansible-lint   | `/ansible/ansible-lint`                    |
-| argcomplete    | `/kislyuk/argcomplete`                     |
 | betterleaks    | `/betterleaks/betterleaks`                 |
 | fnm            | `/schniz/fnm`                              |
 | github-actions | `/websites/github_en_actions`              |

--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ hal update                            # Run all Ansible roles to set up the dev 
 hal update --tags python,node         # Run specific Ansible roles
 hal link ~/.zshrc                     # Move file into dotfiles/ and symlink it back
 hal unlink ~/.zshrc                   # Move file back from dotfiles/ and remove the symlink
-hal copy ~/.config/ghostty/config     # Copy file into dotfiles/ (no symlink)
-hal sync                              # Sync all links and copies
+hal sync                              # Sync all links
 hal backup                            # Back up live data to Dropbox
 hal restore                           # Restore live data from Dropbox (overwrites local)
 hal open-the-pod-bay-doors            # Open the pod bay doors, please, HAL

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -208,7 +208,7 @@ class HAL9000:
 
         return subprocess.run(command, shell=True, cwd=cwd).returncode  # noqa: S602 PLW1510 subprocess-popen-with-shell-equals-true subprocess-run-without-check
 
-    def update(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
+    def update(self, namespace: argparse.Namespace) -> None:
         ansible_path = shutil.which("ansible")
         if ansible_path and not ansible_path.startswith("/opt/homebrew/bin/"):
             self._hal_says(f"Found ansible at: {self._abbreviate_home(ansible_path)}")
@@ -222,14 +222,14 @@ class HAL9000:
 
         playbooks_dir = str(Path(Settings.REPO_ROOT) / "playbooks")
         command = "ansible-playbook site.yml -v"
-        if extra_args:
-            command = " ".join([command, *(shlex.quote(arg) for arg in extra_args)])
+        if namespace.extra_args:
+            command = " ".join([command, *(shlex.quote(arg) for arg in namespace.extra_args)])
         returncode = self._run(command, cwd=playbooks_dir)
         if returncode != 0:
             sys.exit(returncode)
         self._hal_says("Now open a new shell to active your dev environment")
 
-    def link(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
+    def link(self, namespace: argparse.Namespace) -> None:
         filepath, dest_path, template_src, template_dest = self._prepare_dotfile_entry(namespace.filename)
 
         shutil.move(filepath, dest_path)
@@ -246,7 +246,7 @@ class HAL9000:
         self.dotfiles.save()
         self.dotfiles.show()
 
-    def unlink(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
+    def unlink(self, namespace: argparse.Namespace) -> None:
         # abspath, not Path.resolve(): the path at dest IS the symlink this removes, and resolving it would land inside the dotfiles repo
         filepath = Path(os.path.abspath(Path(namespace.filename).expanduser()))  # noqa: PTH100 os-path-abspath
         ln_dict = next((entry for entry in self.dotfiles.data["links"] if Path(self._expand_template(entry["dest"])) == filepath), None)
@@ -276,7 +276,7 @@ class HAL9000:
         self.dotfiles.save()
         self.dotfiles.show()
 
-    def copy(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
+    def copy(self, namespace: argparse.Namespace) -> None:
         filepath, dest_path, template_src, template_dest = self._prepare_dotfile_entry(namespace.filename)
 
         shutil.copy2(filepath, dest_path)
@@ -515,18 +515,18 @@ class HAL9000:
             for future in concurrent.futures.as_completed(futures):
                 future.result()
 
-    def sync(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
+    def sync(self, namespace: argparse.Namespace) -> None:
         tasks: list[Callable[[], None]] = [functools.partial(self._sync_links, link, force=namespace.force) for link in self.dotfiles.data["links"]]
         tasks += [functools.partial(self._copy_entry, copy) for copy in self.dotfiles.data["copies"]]
         self._parallel(tasks)
 
-    def backup(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
+    def backup(self, namespace: argparse.Namespace) -> None:
         self._parallel(functools.partial(self._copy_entry, entry) for entry in self.dotfiles.data["backups"])
 
         if namespace.prune:
             self._prune()
 
-    def restore(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
+    def restore(self, namespace: argparse.Namespace) -> None:  # noqa: ARG002 unused-method-argument
         entries = self.dotfiles.data["backups"]
         if not entries:
             self._hal_says("nothing to restore")
@@ -545,7 +545,7 @@ class HAL9000:
 
         self._parallel(functools.partial(self._copy_entry, Entry(src=entry["dest"], dest=entry["src"])) for entry in entries)
 
-    def open_the_pod_bay_doors(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
+    def open_the_pod_bay_doors(self, namespace: argparse.Namespace) -> None:  # noqa: ARG002 unused-method-argument
         self._hal_says("I'm sorry Dave, I'm afraid I can't do that.")
 
         filepath = str(Path(Settings.REPO_ROOT) / "assets" / "im-sorry-dave-im-afraid-i-cant-do-that.mp3")
@@ -561,7 +561,8 @@ class HAL9000:
         if extra_args and not namespace.passthrough:
             self.parser.parse_args()  # Will error with usage message on unrecognized args
 
-        namespace.func(namespace, extra_args)
+        namespace.extra_args = extra_args
+        namespace.func(namespace)
 
 
 if __name__ == "__main__":

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -22,12 +22,6 @@ if TYPE_CHECKING:
     # The `annotations` future keeps every annotation below a string, so it is never evaluated at runtime
     from typing import NotRequired
 
-# Only needed for generating shell completion during local development
-try:
-    import argcomplete
-except ImportError:
-    argcomplete = None  # ty: ignore[invalid-assignment]
-
 
 def abbreviate_home(path: Path) -> str:
     home = Path.home()
@@ -337,9 +331,6 @@ class HAL9000:
 
         pod_bay_doors_parser = subparsers.add_parser("open-the-pod-bay-doors", help="open the pod bay doors, please, HAL")
         pod_bay_doors_parser.set_defaults(func=self.open_the_pod_bay_doors)
-
-        if argcomplete:
-            argcomplete.autocomplete(parser)
 
     def _hal_says(self, text: str) -> None:
         print(f"HAL: {text}")

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -67,8 +67,8 @@ class Dotfiles:
     # Keys are written back in this order; any other key follows them, sorted by name
     ENTRY_KEY_ORDER: tuple[str, ...] = ("src", "dest", "prune")
 
-    def __init__(self, path: str | Path | None = None) -> None:
-        self.path: Path = Path(path) if path else self.DEFAULT_CONFIG
+    def __init__(self, path: Path | None = None) -> None:
+        self.path: Path = path or self.DEFAULT_CONFIG
         self._data: dict[str, list[Entry]] | None = None
 
     @property
@@ -141,26 +141,23 @@ class Mirror:
         dest.symlink_to(src)
         self._say(f"link {abbreviate_home(src)} -> {abbreviate_home(dest)}")
 
-    # str as well as Path: shutil.copytree hands its copy_function plain strings
     @staticmethod
-    def _is_unchanged(src: str | Path, dest: str | Path) -> bool:
-        dest_path = Path(dest)
-        if not dest_path.exists():
+    def _is_unchanged(src: Path, dest: Path) -> bool:
+        if not dest.exists():
             return False
 
-        src_stat = Path(src).stat()
-        dest_stat = dest_path.stat()
+        src_stat = src.stat()
+        dest_stat = dest.stat()
         # rsync's quick check: equal size and mtime means no rewrite, so Dropbox and Time Machine never re-examine the file
         return src_stat.st_size == dest_stat.st_size and src_stat.st_mtime_ns == dest_stat.st_mtime_ns
 
     @staticmethod
-    def _copy_file_allow_overwrite(src: str | Path, dest: str | Path) -> None:
+    def _copy_file_allow_overwrite(src: Path, dest: Path) -> None:
         if Mirror._is_unchanged(src, dest):
             return
 
-        dest_path = Path(dest)
-        if dest_path.exists() and not dest_path.stat().st_mode & stat.S_IWUSR:
-            dest_path.chmod(dest_path.stat().st_mode | stat.S_IWUSR)
+        if dest.exists() and not dest.stat().st_mode & stat.S_IWUSR:
+            dest.chmod(dest.stat().st_mode | stat.S_IWUSR)
         shutil.copy2(src, dest)
 
     @staticmethod
@@ -177,7 +174,8 @@ class Mirror:
                 src,
                 dest,
                 ignore=shutil.ignore_patterns(*Settings.IGNORE_PATTERNS),
-                copy_function=self._copy_file_allow_overwrite,
+                # copytree hands its copy_function plain strings
+                copy_function=lambda source, target: self._copy_file_allow_overwrite(Path(source), Path(target)),
                 dirs_exist_ok=True,
             )
         else:

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -44,7 +44,6 @@ class PathNotAllowedError(Exception):
 
 
 def abbreviate_home(path: str | Path) -> str:
-    """A single path with its home directory prefix shown as ~, for messages that name one."""
     home = str(Path.home())
     text = str(path)
     return f"~{text[len(home) :]}" if text.startswith(home) else text
@@ -88,7 +87,6 @@ class Dotfiles:
             return {"backups": [], "copies": [], "links": []}
 
     def upsert(self, field_name: str, src: str, dest: str) -> None:
-        """Point the entry for src at dest, adding the entry when there is none."""
         entries = self.data[field_name]
         existing = next((entry for entry in entries if entry["src"] == src), None)
         if existing:
@@ -101,14 +99,12 @@ class Dotfiles:
 
     @staticmethod
     def _ordered_entry(entry: Entry) -> dict[str, object]:
-        """The entry with its keys in ENTRY_KEY_ORDER, any other key after them by name."""
         fields = dict(entry.items())
         known = [key for key in Dotfiles.ENTRY_KEY_ORDER if key in fields]
         unknown = sorted(key for key in fields if key not in Dotfiles.ENTRY_KEY_ORDER)
         return {key: fields[key] for key in [*known, *unknown]}
 
     def _ordered_data(self) -> dict[str, list[dict[str, object]]]:
-        """The manifest as written back to disk, so plain mappings rather than Entry values."""
         return {field_name: [self._ordered_entry(entry) for entry in entries] for field_name, entries in sorted(self.data.items())}
 
     def show(self) -> None:

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -394,7 +394,6 @@ class HAL9000:
             self._hal_says("You should use Homebrew's ansible")
             sys.exit(1)
 
-        self._run("git fetch", cwd=Settings.REPO_ROOT)
         returncode = self._run("git pull", cwd=Settings.REPO_ROOT)
         if returncode != 0:
             sys.exit(returncode)
@@ -414,8 +413,6 @@ class HAL9000:
         shutil.move(paths.filepath, paths.dest_path)
         self._hal_says(f"mv {abbreviate_home(paths.filepath)} -> {abbreviate_home(paths.dest_path)}")
 
-        if paths.filepath.is_symlink() or paths.filepath.exists():
-            paths.filepath.unlink()
         paths.filepath.symlink_to(paths.dest_path)
         self._hal_says(f"ln {abbreviate_home(paths.dest_path)} -> {abbreviate_home(paths.filepath)}")
 

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -57,14 +57,15 @@ class Dotfiles:
     @property
     def data(self) -> dict[str, list[Entry]]:
         if self._data is None:
-            try:
-                with Path(self.path).open() as f:
-                    self._data = json.load(f)
-            except FileNotFoundError:
-                self._data = {"backups": [], "copies": [], "links": []}
-
-        assert self._data is not None  # noqa: S101 assert
+            self._data = self._load()
         return self._data
+
+    def _load(self) -> dict[str, list[Entry]]:
+        try:
+            with Path(self.path).open() as f:
+                return json.load(f)
+        except FileNotFoundError:
+            return {"backups": [], "copies": [], "links": []}
 
     def upsert(self, field_name: str, src: str, dest: str) -> None:
         """Point the entry for src at dest, adding the entry when there is none."""

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -67,9 +67,6 @@ class Dotfiles:
     def remove(self, field_name: str, entry: Entry) -> None:
         self.data[field_name].remove(entry)
 
-    def show(self) -> None:
-        print(json.dumps(self.data, indent=2))
-
     def save(self) -> None:
         with self.path.open("w") as f:
             json.dump(self.data, f, indent=2)
@@ -369,7 +366,6 @@ class HAL9000:
         self.dotfiles.upsert("links", template_src, template_dest)
 
         self.dotfiles.save()
-        self.dotfiles.show()
 
     def unlink(self, namespace: argparse.Namespace) -> None:
         # abspath, not Path.resolve(): the path at dest IS the symlink this removes, and resolving it would land inside the dotfiles repo
@@ -395,11 +391,11 @@ class HAL9000:
         if dest_path.is_symlink():
             dest_path.unlink()
         shutil.move(src_path, dest_path)
+        self._hal_says(f"mv {abbreviate_home(src_path)} -> {abbreviate_home(dest_path)}")
 
         self.dotfiles.remove("links", ln_dict)
 
         self.dotfiles.save()
-        self.dotfiles.show()
 
     def _copy_entry(self, entry: Entry) -> None:
         self.mirror.copy(self._expand_template(entry["src"]), self._expand_template(entry["dest"]))

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -32,7 +32,7 @@ except ImportError:
 
 def abbreviate_home(path: Path) -> str:
     home = Path.home()
-    return f"~{str(path).removeprefix(str(home))}" if path.is_relative_to(home) else str(path)
+    return str(path).replace(str(home), "~", 1) if path.is_relative_to(home) else str(path)
 
 
 class PathNotAllowedError(Exception):

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -12,7 +12,7 @@ import stat
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     # Used only in annotations, so ruff (TC003) wants them imported here rather than at module level
@@ -46,13 +46,6 @@ class Entry(TypedDict):
     src: str
     dest: str
     prune: NotRequired[bool]  # Backup entries only: false keeps --prune away from this destination
-
-
-class DotfilePaths(NamedTuple):
-    filepath: Path
-    dest_path: Path
-    template_src: str
-    template_dest: str
 
 
 class Dotfiles:
@@ -99,14 +92,14 @@ class Dotfiles:
         return {field_name: [self._ordered_entry(entry) for entry in entries] for field_name, entries in sorted(self.data.items())}
 
     def show(self) -> None:
-        print(json.dumps(self._ordered_data(), indent=2, separators=(",", ": ")))
+        print(json.dumps(self._ordered_data(), indent=2))
 
     def save(self) -> None:
         # Read before opening for write: opening truncates, and data loads lazily,
         # so building the payload inside the with block would read back an empty file
         ordered_data = self._ordered_data()
         with self.path.open("w") as f:
-            json.dump(ordered_data, f, indent=2, separators=(",", ": "))
+            json.dump(ordered_data, f, indent=2)
 
 
 # Takes expanded paths only: the manifest, its templates, and the path-safety check stay with HAL9000
@@ -129,8 +122,7 @@ class Mirror:
                 return
             shutil.rmtree(dest)
 
-        if dest.is_symlink() or dest.exists():
-            dest.unlink()
+        dest.unlink(missing_ok=True)
         dest.symlink_to(src)
         self._say(f"link {abbreviate_home(src)} -> {abbreviate_home(dest)}")
 
@@ -277,17 +269,12 @@ class Mirror:
         return True
 
 
-class Formatter(argparse.HelpFormatter):
-    def __init__(self, prog: str) -> None:
-        super().__init__(prog, max_help_position=30)
-
-
 class HAL9000:
     def __init__(self) -> None:
         parser = argparse.ArgumentParser(
             prog="hal",
             description="I am completely operational, and all my circuits are functioning perfectly",
-            formatter_class=Formatter,
+            formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=30),
         )
         self.parser = parser
 
@@ -356,25 +343,6 @@ class HAL9000:
         self._validate_path(expanded)
         return expanded
 
-    def _prepare_dotfile_entry(self, filename: Path) -> DotfilePaths:
-        filepath = (Path.cwd() / filename).resolve()
-        self._validate_path(filepath)
-
-        home = Path.home()
-        if filepath.is_relative_to(home):
-            relative_path = filepath.relative_to(home)
-            template_dest = str(Path("{{HOME}}") / relative_path)
-        else:
-            relative_path = Path(filepath.name)
-            template_dest = str(filepath)
-
-        dest_path = Settings.DOTFILES_ROOT / relative_path
-        dest_path.parent.mkdir(parents=True, exist_ok=True)
-
-        template_src = str(Path("{{REPO_ROOT}}") / dest_path.relative_to(Settings.REPO_ROOT))
-
-        return DotfilePaths(filepath, dest_path, template_src, template_dest)
-
     def _run(self, command: str, *, cwd: Path | None = None, verbose: bool = True) -> int:
         if verbose:
             self._hal_says(command)
@@ -403,15 +371,29 @@ class HAL9000:
         self._hal_says("Now open a new shell to active your dev environment")
 
     def link(self, namespace: argparse.Namespace) -> None:
-        paths = self._prepare_dotfile_entry(namespace.filename)
+        filepath = (Path.cwd() / namespace.filename).resolve()
+        self._validate_path(filepath)
 
-        shutil.move(paths.filepath, paths.dest_path)
-        self._hal_says(f"mv {abbreviate_home(paths.filepath)} -> {abbreviate_home(paths.dest_path)}")
+        home = Path.home()
+        if filepath.is_relative_to(home):
+            relative_path = filepath.relative_to(home)
+            template_dest = str(Path("{{HOME}}") / relative_path)
+        else:
+            relative_path = Path(filepath.name)
+            template_dest = str(filepath)
 
-        paths.filepath.symlink_to(paths.dest_path)
-        self._hal_says(f"ln {abbreviate_home(paths.dest_path)} -> {abbreviate_home(paths.filepath)}")
+        dest_path = Settings.DOTFILES_ROOT / relative_path
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
 
-        self.dotfiles.upsert("links", paths.template_src, paths.template_dest)
+        template_src = str(Path("{{REPO_ROOT}}") / dest_path.relative_to(Settings.REPO_ROOT))
+
+        shutil.move(filepath, dest_path)
+        self._hal_says(f"mv {abbreviate_home(filepath)} -> {abbreviate_home(dest_path)}")
+
+        filepath.symlink_to(dest_path)
+        self._hal_says(f"ln {abbreviate_home(dest_path)} -> {abbreviate_home(filepath)}")
+
+        self.dotfiles.upsert("links", template_src, template_dest)
 
         self.dotfiles.save()
         self.dotfiles.show()

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import fnmatch
-import functools
 import json
 import os
 import shlex
@@ -349,6 +348,16 @@ class HAL9000:
     def _hal_says(self, text: str) -> None:
         print(f"HAL: {text}")
 
+    def _confirm(self, question: str) -> bool:
+        try:
+            answer = input(question)
+        except EOFError:
+            answer = ""
+        if answer.strip().lower() == "y":
+            return True
+        self._hal_says("aborted")
+        return False
+
     def _validate_path(self, path: Path) -> None:
         resolved = path.resolve()
         allowed_roots = (Path.home(), Settings.REPO_ROOT)
@@ -373,8 +382,7 @@ class HAL9000:
             template_dest = str(filepath)
 
         dest_path = Settings.DOTFILES_ROOT / relative_path
-        if dest_path.parent != Settings.DOTFILES_ROOT:
-            dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
 
         template_src = str(Path("{{REPO_ROOT}}") / dest_path.relative_to(Settings.REPO_ROOT))
 
@@ -486,21 +494,15 @@ class HAL9000:
         for path in orphans:
             print(f"  {abbreviate_home(path)}")
 
-        try:
-            answer = input(f"Delete {counted} from backup? [y/N] ")
-        except EOFError:
-            answer = ""
-        if answer.strip().lower() != "y":
-            self._hal_says("aborted")
+        if not self._confirm(f"Delete {counted} from backup? [y/N] "):
             return
 
         removed = sum(self.mirror.remove_orphan(path) for path in reversed(orphans))
         self._hal_says(f"pruned {removed}")
 
-    @staticmethod
-    def _parallel(tasks: Iterable[Callable[[], None]]) -> None:
+    def _copy_entries(self, entries: Iterable[Entry]) -> None:
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = [executor.submit(task) for task in tasks]
+            futures = [executor.submit(self._copy_entry, entry) for entry in entries]
             # Re-raises the first failure, but only after every task has finished: leaving the pool waits for the rest
             for future in concurrent.futures.as_completed(futures):
                 future.result()
@@ -508,10 +510,10 @@ class HAL9000:
     def sync(self, namespace: argparse.Namespace) -> None:
         for link in self.dotfiles.data["links"]:
             self.mirror.link(self._expand_template(link["src"]), self._expand_template(link["dest"]), force=namespace.force)
-        self._parallel(functools.partial(self._copy_entry, copy) for copy in self.dotfiles.data["copies"])
+        self._copy_entries(self.dotfiles.data["copies"])
 
     def backup(self, namespace: argparse.Namespace) -> None:
-        self._parallel(functools.partial(self._copy_entry, entry) for entry in self.dotfiles.data["backups"])
+        self._copy_entries(self.dotfiles.data["backups"])
 
         if namespace.prune:
             self._prune()
@@ -525,15 +527,10 @@ class HAL9000:
         for entry in entries:
             self._hal_says(f"{abbreviate_home(self._expand_template(entry['dest']))} -> {abbreviate_home(self._expand_template(entry['src']))}")
 
-        try:
-            answer = input("Overwrite local files with backups? [y/N] ")
-        except EOFError:
-            answer = ""
-        if answer.strip().lower() != "y":
-            self._hal_says("aborted")
+        if not self._confirm("Overwrite local files with backups? [y/N] "):
             return
 
-        self._parallel(functools.partial(self._copy_entry, Entry(src=entry["dest"], dest=entry["src"])) for entry in entries)
+        self._copy_entries(Entry(src=entry["dest"], dest=entry["src"]) for entry in entries)
 
     def open_the_pod_bay_doors(self, namespace: argparse.Namespace) -> None:  # noqa: ARG002 unused-method-argument
         self._hal_says("I'm sorry Dave, I'm afraid I can't do that.")

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -268,10 +268,15 @@ class HAL9000:
             self._hal_says(f"not found in dotfiles: {self._abbreviate_home(src_path)}")
             return
 
+        # A real directory at dest is one `hal sync` refused to replace, and it may hold files
+        # no manifest entry covers. shutil.move would nest src inside it instead of replacing it.
+        if Path(dest_path).is_dir() and not Path(dest_path).is_symlink():
+            self._hal_says(f"refusing to replace directory {self._abbreviate_home(dest_path)}")
+            return
+
         if Path(dest_path).is_symlink():
             Path(dest_path).unlink()
-        shutil.copy2(src_path, dest_path)
-        Path(src_path).unlink()
+        shutil.move(src_path, dest_path)
 
         self.dotfiles.data["links"].remove(ln_dict)
 

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -67,13 +67,17 @@ class Dotfiles:
         assert self._data is not None  # noqa: S101 assert
         return self._data
 
-    def find_by_key(self, key: str, value: str, field_name: str) -> Entry | None:
+    def upsert(self, field_name: str, src: str, dest: str) -> None:
+        """Point the entry for src at dest, adding the entry when there is none."""
         entries = self.data[field_name]
-        try:
-            # Looked up by a caller-supplied key, which a TypedDict cannot be subscripted with
-            return next(entry for entry in entries if cast("dict[str, object]", entry).get(key) == value)
-        except StopIteration:
-            return None
+        existing = next((entry for entry in entries if entry["src"] == src), None)
+        if existing:
+            existing["dest"] = dest
+        else:
+            entries.append({"dest": dest, "src": src})
+
+    def remove(self, field_name: str, entry: Entry) -> None:
+        self.data[field_name].remove(entry)
 
     @staticmethod
     def _ordered_entry(entry: Entry) -> dict[str, object]:
@@ -232,11 +236,7 @@ class HAL9000:
         ln_dest.symlink_to(dest_path)
         self._hal_says(f"ln {self._abbreviate_home(dest_path)} -> {self._abbreviate_home(filepath)}")
 
-        ln_dict = self.dotfiles.find_by_key("src", template_src, "links")
-        if ln_dict:
-            ln_dict["dest"] = template_dest
-        else:
-            self.dotfiles.data["links"].append({"dest": template_dest, "src": template_src})
+        self.dotfiles.upsert("links", template_src, template_dest)
 
         self.dotfiles.save()
         self.dotfiles.show()
@@ -266,7 +266,7 @@ class HAL9000:
             Path(dest_path).unlink()
         shutil.move(src_path, dest_path)
 
-        self.dotfiles.data["links"].remove(ln_dict)
+        self.dotfiles.remove("links", ln_dict)
 
         self.dotfiles.save()
         self.dotfiles.show()
@@ -277,11 +277,7 @@ class HAL9000:
         shutil.copy2(filepath, dest_path)
         self._hal_says(f"cp {self._abbreviate_home(filepath)} -> {self._abbreviate_home(dest_path)}")
 
-        cp_dict = self.dotfiles.find_by_key("src", template_src, "copies")
-        if cp_dict:
-            cp_dict["dest"] = template_dest
-        else:
-            self.dotfiles.data["copies"].append({"dest": template_dest, "src": template_src})
+        self.dotfiles.upsert("copies", template_src, template_dest)
 
         self.dotfiles.save()
         self.dotfiles.show()

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -55,20 +55,8 @@ class Dotfiles:
 
     def __init__(self, path: Path | None = None) -> None:
         self.path: Path = path or self.DEFAULT_CONFIG
-        self._data: dict[str, list[Entry]] | None = None
-
-    @property
-    def data(self) -> dict[str, list[Entry]]:
-        if self._data is None:
-            self._data = self._load()
-        return self._data
-
-    def _load(self) -> dict[str, list[Entry]]:
-        try:
-            with self.path.open() as f:
-                return json.load(f)
-        except FileNotFoundError:
-            return {"backups": [], "links": []}
+        with self.path.open() as f:
+            self.data: dict[str, list[Entry]] = json.load(f)
 
     def upsert(self, field_name: str, src: str, dest: str) -> None:
         entries = self.data[field_name]
@@ -95,11 +83,8 @@ class Dotfiles:
         print(json.dumps(self._ordered_data(), indent=2))
 
     def save(self) -> None:
-        # Read before opening for write: opening truncates, and data loads lazily,
-        # so building the payload inside the with block would read back an empty file
-        ordered_data = self._ordered_data()
         with self.path.open("w") as f:
-            json.dump(ordered_data, f, indent=2)
+            json.dump(self._ordered_data(), f, indent=2)
 
 
 # Takes expanded paths only: the manifest, its templates, and the path-safety check stay with HAL9000
@@ -477,10 +462,6 @@ class HAL9000:
 
     def restore(self, namespace: argparse.Namespace) -> None:  # noqa: ARG002 unused-method-argument
         entries = self.dotfiles.data["backups"]
-        if not entries:
-            self._hal_says("nothing to restore")
-            return
-
         for entry in entries:
             self._hal_says(f"{abbreviate_home(self._expand_template(entry['dest']))} -> {abbreviate_home(self._expand_template(entry['src']))}")
 

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -190,11 +190,11 @@ class HAL9000:
 
         return filepath, dest_path, template_src, template_dest
 
-    def _run(self, command: str, *, verbose: bool = True) -> int:
+    def _run(self, command: str, *, cwd: str | None = None, verbose: bool = True) -> int:
         if verbose:
             self._hal_says(command)
 
-        return subprocess.run(command, shell=True).returncode  # noqa: S602 PLW1510 subprocess-popen-with-shell-equals-true subprocess-run-without-check
+        return subprocess.run(command, shell=True, cwd=cwd).returncode  # noqa: S602 PLW1510 subprocess-popen-with-shell-equals-true subprocess-run-without-check
 
     def update(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
         ansible_path = shutil.which("ansible")
@@ -203,17 +203,16 @@ class HAL9000:
             self._hal_says("You should use Homebrew's ansible")
             sys.exit(1)
 
-        os.chdir(Settings.REPO_ROOT)
-        self._run("git fetch")
-        returncode = self._run("git pull")
+        self._run("git fetch", cwd=Settings.REPO_ROOT)
+        returncode = self._run("git pull", cwd=Settings.REPO_ROOT)
         if returncode != 0:
             sys.exit(returncode)
 
-        os.chdir(str(Path(Settings.REPO_ROOT) / "playbooks"))
+        playbooks_dir = str(Path(Settings.REPO_ROOT) / "playbooks")
         command = "ansible-playbook site.yml -v"
         if extra_args:
             command = " ".join([command, *(shlex.quote(arg) for arg in extra_args)])
-        returncode = self._run(command)
+        returncode = self._run(command, cwd=playbooks_dir)
         if returncode != 0:
             sys.exit(returncode)
         self._hal_says("Now open a new shell to active your dev environment")

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -5,6 +5,7 @@ import argparse
 import concurrent.futures
 import fnmatch
 import json
+import os
 import shlex
 import shutil
 import stat
@@ -214,8 +215,6 @@ class HAL9000:
                 self._hal_says("You should use Homebrew's ansible")
                 sys.exit(1)
 
-        import os  # noqa: PLC0415 import-outside-top-level
-
         os.chdir(Settings.REPO_ROOT)
         self._run("git fetch")
         returncode = self._run("git pull")
@@ -253,12 +252,11 @@ class HAL9000:
         self.dotfiles.show()
 
     def unlink(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
-        relative_path = namespace.filename.removeprefix("~/")
-        template_dest = "{{HOME}}/" + relative_path
-
-        ln_dict = self.dotfiles.find_by_key("dest", template_dest, "links")
+        # abspath, not Path.resolve(): the path at dest IS the symlink this removes, and resolving it would land inside the dotfiles repo
+        filepath = Path(os.path.abspath(Path(namespace.filename).expanduser()))  # noqa: PTH100 os-path-abspath
+        ln_dict = next((entry for entry in self.dotfiles.data["links"] if Path(self._expand_template(entry["dest"])) == filepath), None)
         if not ln_dict:
-            self._hal_says(f"not found in manifest: {relative_path}")
+            self._hal_says(f"not found in manifest: {self._abbreviate_home(filepath)}")
             return
 
         src_path = self._expand_template(ln_dict["src"])

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -509,8 +509,6 @@ class HAL9000:
                 future.result()
 
     def sync(self, namespace: argparse.Namespace) -> None:
-        # Links are metadata syscalls, so a thread pool costs more in spin-up than it saves; running them
-        # in manifest order also keeps the output stable
         for link in self.dotfiles.data["links"]:
             self.mirror.link(self._expand_template(link["src"]), self._expand_template(link["dest"]), force=namespace.force)
         self._parallel(functools.partial(self._copy_entry, copy) for copy in self.dotfiles.data["copies"])

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -190,30 +190,18 @@ class HAL9000:
 
         return filepath, dest_path, template_src, template_dest
 
-    def _run(self, command: str, *, shell: bool = True, verbose: bool = True) -> int:
+    def _run(self, command: str, *, verbose: bool = True) -> int:
         if verbose:
             self._hal_says(command)
 
-        return subprocess.run(command, shell=shell).returncode  # noqa: S603 PLW1510 subprocess-without-shell-equals-true subprocess-run-without-check
-
-    def _run_with_output(self, command: str, *, shell: bool = True, verbose: bool = True, print_output: bool = True) -> tuple[int, bytes]:
-        if verbose:
-            self._hal_says(command)
-
-        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=shell)  # noqa: S603 PLW1510 subprocess-without-shell-equals-true subprocess-run-without-check
-        if print_output and result.stdout:
-            print(result.stdout, end="")
-
-        return result.returncode, result.stdout
+        return subprocess.run(command, shell=True).returncode  # noqa: S602 PLW1510 subprocess-popen-with-shell-equals-true subprocess-run-without-check
 
     def update(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
-        returncode, output = self._run_with_output("which ansible", print_output=False)
-        if returncode == 0:
-            ansible_path = output.decode().strip()
-            if not ansible_path.startswith("/opt/homebrew/bin/"):
-                self._hal_says(f"Found ansible at: {self._abbreviate_home(ansible_path)}")
-                self._hal_says("You should use Homebrew's ansible")
-                sys.exit(1)
+        ansible_path = shutil.which("ansible")
+        if ansible_path and not ansible_path.startswith("/opt/homebrew/bin/"):
+            self._hal_says(f"Found ansible at: {self._abbreviate_home(ansible_path)}")
+            self._hal_says("You should use Homebrew's ansible")
+            sys.exit(1)
 
         os.chdir(Settings.REPO_ROOT)
         self._run("git fetch")

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -81,7 +81,7 @@ class Dotfiles:
             with self.path.open() as f:
                 return json.load(f)
         except FileNotFoundError:
-            return {"backups": [], "copies": [], "links": []}
+            return {"backups": [], "links": []}
 
     def upsert(self, field_name: str, src: str, dest: str) -> None:
         entries = self.data[field_name]
@@ -324,11 +324,7 @@ class HAL9000:
         unlink_parser.set_defaults(func=self.unlink)
         unlink_parser.add_argument("filename", type=Path)
 
-        copy_parser = subparsers.add_parser("copy", help="copy file into dotfiles (no symlink)")
-        copy_parser.set_defaults(func=self.copy)
-        copy_parser.add_argument("filename", type=Path)
-
-        sync_parser = subparsers.add_parser("sync", help="sync all links and copies")
+        sync_parser = subparsers.add_parser("sync", help="sync all links")
         sync_parser.set_defaults(func=self.sync)
         sync_parser.add_argument("--force", action="store_true", help="replace real directories at link destinations")
 
@@ -459,17 +455,6 @@ class HAL9000:
         self.dotfiles.save()
         self.dotfiles.show()
 
-    def copy(self, namespace: argparse.Namespace) -> None:
-        paths = self._prepare_dotfile_entry(namespace.filename)
-
-        shutil.copy2(paths.filepath, paths.dest_path)
-        self._hal_says(f"cp {abbreviate_home(paths.filepath)} -> {abbreviate_home(paths.dest_path)}")
-
-        self.dotfiles.upsert("copies", paths.template_src, paths.template_dest)
-
-        self.dotfiles.save()
-        self.dotfiles.show()
-
     def _copy_entry(self, entry: Entry) -> None:
         self.mirror.copy(self._expand_template(entry["src"]), self._expand_template(entry["dest"]))
 
@@ -510,7 +495,6 @@ class HAL9000:
     def sync(self, namespace: argparse.Namespace) -> None:
         for link in self.dotfiles.data["links"]:
             self.mirror.link(self._expand_template(link["src"]), self._expand_template(link["dest"]), force=namespace.force)
-        self._copy_entries(self.dotfiles.data["copies"])
 
     def backup(self, namespace: argparse.Namespace) -> None:
         self._copy_entries(self.dotfiles.data["backups"])

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -216,16 +216,16 @@ class Mirror:
         self._copy_one(src, dest)
 
     @staticmethod
-    def _walk_names(root: Path, *, follow_symlinks: bool) -> set[str]:
-        names: set[str] = set()
+    def _walk_names(root: Path, *, follow_symlinks: bool) -> set[Path]:
+        names: set[Path] = set()
         visited = {root.resolve()}
-        stack = [(root, "")]
+        stack = [(root, Path())]
         while stack:
             directory, prefix = stack.pop()
             for child in directory.iterdir():
                 if Mirror._is_ignored(child, Settings.IGNORE_PATTERNS + Settings.DIFF_IGNORE_PATTERNS):
                     continue
-                relative = f"{prefix}/{child.name}" if prefix else child.name
+                relative = prefix / child.name
                 names.add(relative)
                 if not child.is_dir():
                     continue
@@ -319,15 +319,15 @@ class HAL9000:
 
         link_parser = subparsers.add_parser("link", help="move file into dotfiles and symlink it back")
         link_parser.set_defaults(func=self.link)
-        link_parser.add_argument("filename", type=str)
+        link_parser.add_argument("filename", type=Path)
 
         unlink_parser = subparsers.add_parser("unlink", help="move file back from dotfiles and remove symlink")
         unlink_parser.set_defaults(func=self.unlink)
-        unlink_parser.add_argument("filename", type=str)
+        unlink_parser.add_argument("filename", type=Path)
 
         copy_parser = subparsers.add_parser("copy", help="copy file into dotfiles (no symlink)")
         copy_parser.set_defaults(func=self.copy)
-        copy_parser.add_argument("filename", type=str)
+        copy_parser.add_argument("filename", type=Path)
 
         sync_parser = subparsers.add_parser("sync", help="sync all links and copies")
         sync_parser.set_defaults(func=self.sync)
@@ -360,7 +360,7 @@ class HAL9000:
         self._validate_path(expanded)
         return expanded
 
-    def _prepare_dotfile_entry(self, filename: str) -> DotfilePaths:
+    def _prepare_dotfile_entry(self, filename: Path) -> DotfilePaths:
         filepath = (Path.cwd() / filename).resolve()
         self._validate_path(filepath)
 
@@ -387,9 +387,10 @@ class HAL9000:
         return subprocess.run(command, shell=True, cwd=cwd).returncode  # noqa: S602 PLW1510 subprocess-popen-with-shell-equals-true subprocess-run-without-check
 
     def update(self, namespace: argparse.Namespace) -> None:
-        ansible_path = shutil.which("ansible")
-        if ansible_path and not ansible_path.startswith("/opt/homebrew/bin/"):
-            self._hal_says(f"Found ansible at: {abbreviate_home(Path(ansible_path))}")
+        which = shutil.which("ansible")
+        ansible_path = Path(which) if which else None
+        if ansible_path and not ansible_path.is_relative_to("/opt/homebrew/bin"):
+            self._hal_says(f"Found ansible at: {abbreviate_home(ansible_path)}")
             self._hal_says("You should use Homebrew's ansible")
             sys.exit(1)
 
@@ -425,7 +426,7 @@ class HAL9000:
 
     def unlink(self, namespace: argparse.Namespace) -> None:
         # abspath, not Path.resolve(): the path at dest IS the symlink this removes, and resolving it would land inside the dotfiles repo
-        filepath = Path(os.path.abspath(Path(namespace.filename).expanduser()))  # noqa: PTH100 os-path-abspath
+        filepath = Path(os.path.abspath(namespace.filename.expanduser()))  # noqa: PTH100 os-path-abspath
         ln_dict = next((entry for entry in self.dotfiles.data["links"] if self._expand_template(entry["dest"]) == filepath), None)
         if not ln_dict:
             self._hal_says(f"not found in manifest: {abbreviate_home(filepath)}")

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -30,10 +30,9 @@ except ImportError:
     argcomplete = None  # ty: ignore[invalid-assignment]
 
 
-def abbreviate_home(path: str | Path) -> str:
-    home = str(Path.home())
-    text = str(path)
-    return f"~{text[len(home) :]}" if text.startswith(home) else text
+def abbreviate_home(path: Path) -> str:
+    home = Path.home()
+    return f"~{str(path)[len(str(home)) :]}" if path.is_relative_to(home) else str(path)
 
 
 class PathNotAllowedError(Exception):
@@ -392,7 +391,7 @@ class HAL9000:
     def update(self, namespace: argparse.Namespace) -> None:
         ansible_path = shutil.which("ansible")
         if ansible_path and not ansible_path.startswith("/opt/homebrew/bin/"):
-            self._hal_says(f"Found ansible at: {abbreviate_home(ansible_path)}")
+            self._hal_says(f"Found ansible at: {abbreviate_home(Path(ansible_path))}")
             self._hal_says("You should use Homebrew's ansible")
             sys.exit(1)
 

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -175,12 +175,12 @@ class Mirror:
         shutil.copy2(src, dest)
 
     @staticmethod
-    def _is_ignored(path: str) -> bool:
+    def _is_ignored(path: str, patterns: tuple[str, ...]) -> bool:
         name = Path(path).name
-        return any(fnmatch.fnmatch(name, pattern) for pattern in Settings.IGNORE_PATTERNS)
+        return any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
 
     def _copy_one(self, src: str, dest: str) -> None:
-        if self._is_ignored(src):
+        if self._is_ignored(src, Settings.IGNORE_PATTERNS):
             self._say(f"ignored {abbreviate_home(src)}")
             return
 
@@ -247,7 +247,7 @@ class Mirror:
         while stack:
             directory, prefix = stack.pop()
             for child in directory.iterdir():
-                if Mirror._is_ignored(str(child)) or child.name in Settings.DIFF_IGNORE_PATTERNS:
+                if Mirror._is_ignored(str(child), Settings.IGNORE_PATTERNS + Settings.DIFF_IGNORE_PATTERNS):
                     continue
                 relative = f"{prefix}/{child.name}" if prefix else child.name
                 names.add(relative)
@@ -297,7 +297,7 @@ class Mirror:
         # filtered out of the diff and never listed. Clear those, then rmdir, which
         # still refuses any directory holding something the listing did not account for.
         for child in path.iterdir():
-            if not self._is_ignored(str(child)):
+            if not self._is_ignored(str(child), Settings.IGNORE_PATTERNS):
                 continue
             if child.is_dir() and not child.is_symlink():
                 shutil.rmtree(child)

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -527,7 +527,7 @@ class HAL9000:
             self._hal_says("aborted")
             return
 
-        removed = sum(self.mirror.remove_orphan(path) for path in sorted(orphans, reverse=True))
+        removed = sum(self.mirror.remove_orphan(path) for path in reversed(orphans))
         self._hal_says(f"pruned {removed}")
 
     @staticmethod

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import fnmatch
+import functools
 import json
 import os
 import shlex
@@ -15,6 +16,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict, cast
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     # NotRequired is 3.11+, but this runs under whatever `python3` resolves to, which on a stock macOS is 3.9
     # The `annotations` future keeps every annotation below a string, so it is never evaluated at runtime
     from typing import NotRequired
@@ -499,19 +502,25 @@ class HAL9000:
         removed = sum(self._remove_orphan(path) for path in sorted(orphans, reverse=True))
         self._hal_says(f"pruned {removed}")
 
-    def sync(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
+    @staticmethod
+    def _parallel(tasks: Iterable[Callable[[], None]]) -> None:
+        """Run every task on a thread pool.
+
+        The first failure is re-raised on the calling thread, but only after every task
+        has finished, because leaving the pool waits for the ones still running.
+        """
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures: list[concurrent.futures.Future[None]] = []
-            futures.extend(executor.submit(self._sync_links, link, force=namespace.force) for link in self.dotfiles.data["links"])
-            futures.extend(executor.submit(self._copy_entry, copy) for copy in self.dotfiles.data["copies"])
-            for f in concurrent.futures.as_completed(futures):
-                f.result()
+            futures = [executor.submit(task) for task in tasks]
+            for future in concurrent.futures.as_completed(futures):
+                future.result()
+
+    def sync(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
+        tasks: list[Callable[[], None]] = [functools.partial(self._sync_links, link, force=namespace.force) for link in self.dotfiles.data["links"]]
+        tasks += [functools.partial(self._copy_entry, copy) for copy in self.dotfiles.data["copies"]]
+        self._parallel(tasks)
 
     def backup(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = [executor.submit(self._copy_entry, entry) for entry in self.dotfiles.data["backups"]]
-            for f in concurrent.futures.as_completed(futures):
-                f.result()
+        self._parallel(functools.partial(self._copy_entry, entry) for entry in self.dotfiles.data["backups"])
 
         if namespace.prune:
             self._prune()
@@ -533,10 +542,7 @@ class HAL9000:
             self._hal_says("aborted")
             return
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = [executor.submit(self._copy_entry, {"src": entry["dest"], "dest": entry["src"]}) for entry in entries]
-            for f in concurrent.futures.as_completed(futures):
-                f.result()
+        self._parallel(functools.partial(self._copy_entry, Entry(src=entry["dest"], dest=entry["src"])) for entry in entries)
 
     def open_the_pod_bay_doors(self, namespace: argparse.Namespace, extra_args: list[str] | None = None) -> None:  # noqa: ARG002 unused-method-argument
         self._hal_says("I'm sorry Dave, I'm afraid I can't do that.")

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -39,6 +39,10 @@ class Settings:
     DIFF_IGNORE_PATTERNS: tuple[str, ...] = (".git",)
 
 
+class PathNotAllowedError(Exception):
+    """A path outside the home directory and the repo, the only places hal touches."""
+
+
 def abbreviate_home(path: str | Path) -> str:
     """A single path with its home directory prefix shown as ~, for messages that name one."""
     home = str(Path.home())
@@ -381,8 +385,7 @@ class HAL9000:
         resolved = Path(path).resolve()
         allowed_roots = (Path.home(), Path(Settings.REPO_ROOT))
         if not any(resolved.is_relative_to(root) for root in allowed_roots):
-            self._hal_says(f"I'm sorry, Dave. I'm afraid I can't do that: {abbreviate_home(resolved)}")
-            sys.exit(1)
+            raise PathNotAllowedError(abbreviate_home(resolved))
 
     def _expand_template(self, path: str) -> str:
         expanded = path.replace("{{HOME}}", str(Path.home())).replace("{{REPO_ROOT}}", Settings.REPO_ROOT)
@@ -589,7 +592,11 @@ class HAL9000:
             self.parser.parse_args()  # Will error with usage message on unrecognized args
 
         namespace.extra_args = extra_args
-        namespace.func(namespace)
+        try:
+            namespace.func(namespace)
+        except PathNotAllowedError as error:
+            self._hal_says(f"I'm sorry, Dave. I'm afraid I can't do that: {error}")
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -50,8 +50,6 @@ class Entry(TypedDict):
 
 class Dotfiles:
     DEFAULT_CONFIG: Path = Settings.DOTFILES_ROOT / "hal_dotfiles.json"
-    # Keys are written back in this order; any other key follows them, sorted by name
-    ENTRY_KEY_ORDER: tuple[str, ...] = ("src", "dest", "prune")
 
     def __init__(self, path: Path | None = None) -> None:
         self.path: Path = path or self.DEFAULT_CONFIG
@@ -64,27 +62,17 @@ class Dotfiles:
         if existing:
             existing["dest"] = dest
         else:
-            entries.append({"dest": dest, "src": src})
+            entries.append({"src": src, "dest": dest})
 
     def remove(self, field_name: str, entry: Entry) -> None:
         self.data[field_name].remove(entry)
 
-    @staticmethod
-    def _ordered_entry(entry: Entry) -> dict[str, object]:
-        fields = dict(entry.items())
-        known = [key for key in Dotfiles.ENTRY_KEY_ORDER if key in fields]
-        unknown = sorted(key for key in fields if key not in Dotfiles.ENTRY_KEY_ORDER)
-        return {key: fields[key] for key in [*known, *unknown]}
-
-    def _ordered_data(self) -> dict[str, list[dict[str, object]]]:
-        return {field_name: [self._ordered_entry(entry) for entry in entries] for field_name, entries in sorted(self.data.items())}
-
     def show(self) -> None:
-        print(json.dumps(self._ordered_data(), indent=2))
+        print(json.dumps(self.data, indent=2))
 
     def save(self) -> None:
         with self.path.open("w") as f:
-            json.dump(self._ordered_data(), f, indent=2)
+            json.dump(self.data, f, indent=2)
 
 
 # Takes expanded paths only: the manifest, its templates, and the path-safety check stay with HAL9000

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -366,20 +366,33 @@ class HAL9000:
             shutil.copy2(src, dest)
         self._hal_says(f"copy {self._abbreviate_home(src)} -> {self._abbreviate_home(dest)}")
 
+    def _glob_pairs(self, entry: Entry) -> list[tuple[str, str]]:
+        """The (src, dest) pairs a single-`*` entry expands to, with each star spliced into dest.
+
+        Copying and pruning have to read a pattern pair the same way: these destinations are
+        exactly the ones a backup writes, so anything else matching the dest pattern is an orphan.
+        """
+        src = self._expand_template(entry["src"])
+        dest = self._expand_template(entry["dest"])
+        prefix, _, suffix = src.partition("*")
+        dprefix, _, dsuffix = dest.partition("*")
+        matches = sorted(str(match) for match in Path(src).parent.glob(Path(src).name))
+        pairs = []
+        for match in matches:
+            star = match[len(prefix) : len(match) - len(suffix)]
+            pairs.append((match, f"{dprefix}{star}{dsuffix}"))
+        return pairs
+
     def _copy_entry(self, entry: Entry) -> None:
         src = self._expand_template(entry["src"])
 
         if "*" in src:
-            dest = self._expand_template(entry["dest"])
-            prefix, _, suffix = src.partition("*")
-            dprefix, _, dsuffix = dest.partition("*")
-            matches = sorted(str(match) for match in Path(src).parent.glob(Path(src).name))
-            if not matches:
+            pairs = self._glob_pairs(entry)
+            if not pairs:
                 self._hal_says(f"no matches {self._abbreviate_home(src)}")
                 return
-            for match in matches:
-                star = match[len(prefix) : len(match) - len(suffix)]
-                self._copy_one(match, f"{dprefix}{star}{dsuffix}")
+            for match, match_dest in pairs:
+                self._copy_one(match, match_dest)
             return
 
         if not Path(src).exists():
@@ -430,10 +443,11 @@ class HAL9000:
         dest = Path(self._expand_template(entry["dest"]))
 
         if "*" in str(src):
-            src_names = {match.name for match in src.parent.glob(src.name)}
-            if not src_names:
+            pairs = self._glob_pairs(entry)
+            if not pairs:
                 return []
-            return sorted(match for match in dest.parent.glob(dest.name) if match.name not in src_names)
+            expected = {Path(pair_dest) for _, pair_dest in pairs}
+            return sorted(match for match in dest.parent.glob(dest.name) if match not in expected)
 
         if not src.is_dir() or not dest.is_dir():
             return []

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -40,7 +40,7 @@ class Settings:
 
 
 class PathNotAllowedError(Exception):
-    """A path outside the home directory and the repo, the only places hal touches."""
+    pass
 
 
 def abbreviate_home(path: str | Path) -> str:
@@ -56,8 +56,6 @@ class Entry(TypedDict):
 
 
 class DotfilePaths(NamedTuple):
-    """Where hal link and hal copy put a file, and how the manifest records it."""
-
     filepath: str
     dest_path: str
     template_src: str
@@ -118,13 +116,8 @@ class Dotfiles:
             json.dump(ordered_data, f, indent=2, separators=(",", ": "))
 
 
+# Takes expanded paths only: the manifest, its templates, and the path-safety check stay with HAL9000
 class Mirror:
-    """Copies, links, and diffs real paths, reporting each step through say.
-
-    Everything here takes expanded paths: the manifest, its templates, and the
-    path-safety check stay with the caller.
-    """
-
     def __init__(self, say: Callable[[str], None]) -> None:
         self._say = say
 
@@ -152,16 +145,13 @@ class Mirror:
 
     @staticmethod
     def _is_unchanged(src: str, dest: str) -> bool:
-        """Same quick check as rsync: matching size and mtime means no rewrite needed.
-
-        Rewriting an identical file makes Dropbox and Time Machine re-examine it, so skip it.
-        """
         dest_path = Path(dest)
         if not dest_path.exists():
             return False
 
         src_stat = Path(src).stat()
         dest_stat = dest_path.stat()
+        # rsync's quick check: equal size and mtime means no rewrite, so Dropbox and Time Machine never re-examine the file
         return src_stat.st_size == dest_stat.st_size and src_stat.st_mtime_ns == dest_stat.st_mtime_ns
 
     @staticmethod
@@ -202,11 +192,8 @@ class Mirror:
 
     @staticmethod
     def _glob_pairs(src: str, dest: str) -> list[tuple[str, str]]:
-        """The (src, dest) pairs a single-`*` entry expands to, with each star spliced into dest.
-
-        Copying and pruning have to read a pattern pair the same way: these destinations are
-        exactly the ones a backup writes, so anything else matching the dest pattern is an orphan.
-        """
+        # Shared by copy and find_orphans so both read a pattern pair the same way: these destinations are
+        # exactly the ones a backup writes, so anything else matching the dest pattern is an orphan
         prefix, _, suffix = src.partition("*")
         dprefix, _, dsuffix = dest.partition("*")
         matches = sorted(str(match) for match in Path(src).parent.glob(Path(src).name))
@@ -234,13 +221,6 @@ class Mirror:
 
     @staticmethod
     def _walk_names(root: Path, *, follow_symlinks: bool) -> set[str]:
-        """Every path under root, relative to it, skipping ignored names.
-
-        A source is walked through its symlinked directories because backup copies them
-        dereferenced, leaving the destination holding their contents as real files; not
-        descending would read every one of those files as an orphan. A destination is not,
-        so a symlink there stays a single entry to unlink rather than a way out of the backup.
-        """
         names: set[str] = set()
         visited = {root.resolve()}
         stack = [(root, "")]
@@ -254,6 +234,9 @@ class Mirror:
                 if not child.is_dir():
                     continue
                 if child.is_symlink():
+                    # A source is followed because backup copies symlinked directories dereferenced, so their contents
+                    # sit in the destination as real files and would otherwise all read as orphans. A destination is
+                    # not, so a symlink there stays a single entry to unlink rather than a way out of the backup.
                     if not follow_symlinks:
                         continue
                     resolved = child.resolve()
@@ -265,11 +248,6 @@ class Mirror:
 
     @staticmethod
     def find_orphans(src: str, dest: str) -> list[Path]:
-        """Paths in the backup destination that no longer exist in its source.
-
-        A source that is missing or empty yields nothing: there the backup is the only
-        surviving copy, and every file in it would otherwise read as an orphan.
-        """
         dest_path = Path(dest)
 
         if "*" in src:
@@ -280,6 +258,7 @@ class Mirror:
             return sorted(match for match in dest_path.parent.glob(dest_path.name) if match not in expected)
 
         src_path = Path(src)
+        # A missing or empty source means the backup is the only surviving copy, and every file in it would read as an orphan
         if not src_path.is_dir() or not dest_path.is_dir():
             return []
 
@@ -531,13 +510,9 @@ class HAL9000:
 
     @staticmethod
     def _parallel(tasks: Iterable[Callable[[], None]]) -> None:
-        """Run every task on a thread pool.
-
-        The first failure is re-raised on the calling thread, but only after every task
-        has finished, because leaving the pool waits for the ones still running.
-        """
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = [executor.submit(task) for task in tasks]
+            # Re-raises the first failure, but only after every task has finished: leaving the pool waits for the rest
             for future in concurrent.futures.as_completed(futures):
                 future.result()
 

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -366,7 +366,7 @@ class HAL9000:
                 self._hal_says(f"unchanged {self._abbreviate_home(src)}")
                 return
             Path(dest).parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(src, dest)
+            self._copy_file_allow_overwrite(src, dest)
         self._hal_says(f"copy {self._abbreviate_home(src)} -> {self._abbreviate_home(dest)}")
 
     def _glob_pairs(self, entry: Entry) -> list[tuple[str, str]]:

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -13,7 +13,7 @@ import stat
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, NamedTuple, TypedDict
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -43,6 +43,15 @@ class Entry(TypedDict):
     src: str
     dest: str
     prune: NotRequired[bool]  # Backup entries only: false keeps --prune away from this destination
+
+
+class DotfilePaths(NamedTuple):
+    """Where hal link and hal copy put a file, and how the manifest records it."""
+
+    filepath: str
+    dest_path: str
+    template_src: str
+    template_dest: str
 
 
 class Dotfiles:
@@ -184,7 +193,7 @@ class HAL9000:
         self._validate_path(expanded)
         return expanded
 
-    def _prepare_dotfile_entry(self, filename: str) -> tuple[str, str, str, str]:
+    def _prepare_dotfile_entry(self, filename: str) -> DotfilePaths:
         filepath = str((Path.cwd() / filename).resolve())
         self._validate_path(filepath)
 
@@ -200,7 +209,7 @@ class HAL9000:
         template_src = dest_path.replace(Settings.REPO_ROOT, "{{REPO_ROOT}}")
         template_dest = filepath.replace(home, "{{HOME}}")
 
-        return filepath, dest_path, template_src, template_dest
+        return DotfilePaths(filepath, dest_path, template_src, template_dest)
 
     def _run(self, command: str, *, cwd: str | None = None, verbose: bool = True) -> int:
         if verbose:
@@ -230,18 +239,18 @@ class HAL9000:
         self._hal_says("Now open a new shell to active your dev environment")
 
     def link(self, namespace: argparse.Namespace) -> None:
-        filepath, dest_path, template_src, template_dest = self._prepare_dotfile_entry(namespace.filename)
+        paths = self._prepare_dotfile_entry(namespace.filename)
 
-        shutil.move(filepath, dest_path)
-        self._hal_says(f"mv {self._abbreviate_home(filepath)} -> {self._abbreviate_home(dest_path)}")
+        shutil.move(paths.filepath, paths.dest_path)
+        self._hal_says(f"mv {self._abbreviate_home(paths.filepath)} -> {self._abbreviate_home(paths.dest_path)}")
 
-        ln_dest = Path(filepath)
+        ln_dest = Path(paths.filepath)
         if ln_dest.is_symlink() or ln_dest.exists():
             ln_dest.unlink()
-        ln_dest.symlink_to(dest_path)
-        self._hal_says(f"ln {self._abbreviate_home(dest_path)} -> {self._abbreviate_home(filepath)}")
+        ln_dest.symlink_to(paths.dest_path)
+        self._hal_says(f"ln {self._abbreviate_home(paths.dest_path)} -> {self._abbreviate_home(paths.filepath)}")
 
-        self.dotfiles.upsert("links", template_src, template_dest)
+        self.dotfiles.upsert("links", paths.template_src, paths.template_dest)
 
         self.dotfiles.save()
         self.dotfiles.show()
@@ -277,12 +286,12 @@ class HAL9000:
         self.dotfiles.show()
 
     def copy(self, namespace: argparse.Namespace) -> None:
-        filepath, dest_path, template_src, template_dest = self._prepare_dotfile_entry(namespace.filename)
+        paths = self._prepare_dotfile_entry(namespace.filename)
 
-        shutil.copy2(filepath, dest_path)
-        self._hal_says(f"cp {self._abbreviate_home(filepath)} -> {self._abbreviate_home(dest_path)}")
+        shutil.copy2(paths.filepath, paths.dest_path)
+        self._hal_says(f"cp {self._abbreviate_home(paths.filepath)} -> {self._abbreviate_home(paths.dest_path)}")
 
-        self.dotfiles.upsert("copies", template_src, template_dest)
+        self.dotfiles.upsert("copies", paths.template_src, paths.template_dest)
 
         self.dotfiles.save()
         self.dotfiles.show()

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -30,6 +30,16 @@ except ImportError:
     argcomplete = None  # ty: ignore[invalid-assignment]
 
 
+def abbreviate_home(path: str | Path) -> str:
+    home = str(Path.home())
+    text = str(path)
+    return f"~{text[len(home) :]}" if text.startswith(home) else text
+
+
+class PathNotAllowedError(Exception):
+    pass
+
+
 class Settings:
     REPO_ROOT: str = str(Path(__file__).resolve().parent.parent)
     DOTFILES_ROOT: str = str(Path(REPO_ROOT) / "dotfiles")
@@ -38,16 +48,6 @@ class Settings:
     # git reclaims loose objects and packs locally, so a copy-only backup keeps every
     # superseded one forever and they would drown out the orphans worth seeing.
     DIFF_IGNORE_PATTERNS: tuple[str, ...] = (".git",)
-
-
-class PathNotAllowedError(Exception):
-    pass
-
-
-def abbreviate_home(path: str | Path) -> str:
-    home = str(Path.home())
-    text = str(path)
-    return f"~{text[len(home) :]}" if text.startswith(home) else text
 
 
 class Entry(TypedDict):

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple, TypedDict
 
 if TYPE_CHECKING:
+    # Used only in annotations, so ruff (TC003) wants them imported here rather than at module level
     from collections.abc import Callable, Iterable
 
     # NotRequired is 3.11+, but this runs under whatever `python3` resolves to, which on a stock macOS is 3.9

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -118,6 +118,9 @@ class HAL9000:
 
         self.parser.add_argument("-v", "--version", action="version", version="9000")
 
+        # Commands that forward unrecognized arguments override this on their own subparser
+        parser.set_defaults(passthrough=False)
+
         subparsers = parser.add_subparsers(title="sub commands")
 
         update_parser = subparsers.add_parser(
@@ -126,7 +129,7 @@ class HAL9000:
             usage="hal update [-h] [ansible-playbook args ...]",
             description="pull repo and run ansible-playbook; extra args pass through to ansible-playbook, e.g. hal update --tags python,node",
         )
-        update_parser.set_defaults(func=self.update)
+        update_parser.set_defaults(func=self.update, passthrough=True)
 
         self.dotfiles = Dotfiles()
 
@@ -555,7 +558,7 @@ class HAL9000:
 
         namespace, extra_args = self.parser.parse_known_args()
 
-        if extra_args and namespace.func != self.update:
+        if extra_args and not namespace.passthrough:
             self.parser.parse_args()  # Will error with usage message on unrecognized args
 
         namespace.func(namespace, extra_args)

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -39,6 +39,13 @@ class Settings:
     DIFF_IGNORE_PATTERNS: tuple[str, ...] = (".git",)
 
 
+def abbreviate_home(path: str | Path) -> str:
+    """A single path with its home directory prefix shown as ~, for messages that name one."""
+    home = str(Path.home())
+    text = str(path)
+    return f"~{text[len(home) :]}" if text.startswith(home) else text
+
+
 class Entry(TypedDict):
     src: str
     dest: str
@@ -111,6 +118,200 @@ class Dotfiles:
             json.dump(ordered_data, f, indent=2, separators=(",", ": "))
 
 
+class Mirror:
+    """Copies, links, and diffs real paths, reporting each step through say.
+
+    Everything here takes expanded paths: the manifest, its templates, and the
+    path-safety check stay with the caller.
+    """
+
+    def __init__(self, say: Callable[[str], None]) -> None:
+        self._say = say
+
+    def link(self, src: str, dest: str, *, force: bool = False) -> None:
+        if not Path(src).exists():
+            self._say(f"not found {abbreviate_home(src)}")
+            return
+
+        dest = dest.rstrip("/")
+        Path(dest).parent.mkdir(parents=True, exist_ok=True)
+
+        # If dest already exists as a real directory, remove it so the symlink replaces it.
+        # It may hold files no manifest entry covers, so make destroying them explicit.
+        if Path(dest).is_dir() and not Path(dest).is_symlink():
+            if not force:
+                self._say(f"refusing to replace directory {abbreviate_home(dest)}, re-run with --force")
+                return
+            shutil.rmtree(dest)
+
+        dest_path = Path(dest)
+        if dest_path.is_symlink() or dest_path.exists():
+            dest_path.unlink()
+        dest_path.symlink_to(src)
+        self._say(f"link {abbreviate_home(src)} -> {abbreviate_home(dest)}")
+
+    @staticmethod
+    def _is_unchanged(src: str, dest: str) -> bool:
+        """Same quick check as rsync: matching size and mtime means no rewrite needed.
+
+        Rewriting an identical file makes Dropbox and Time Machine re-examine it, so skip it.
+        """
+        dest_path = Path(dest)
+        if not dest_path.exists():
+            return False
+
+        src_stat = Path(src).stat()
+        dest_stat = dest_path.stat()
+        return src_stat.st_size == dest_stat.st_size and src_stat.st_mtime_ns == dest_stat.st_mtime_ns
+
+    @staticmethod
+    def _copy_file_allow_overwrite(src: str, dest: str) -> None:
+        if Mirror._is_unchanged(src, dest):
+            return
+
+        dest_path = Path(dest)
+        if dest_path.exists() and not dest_path.stat().st_mode & stat.S_IWUSR:
+            dest_path.chmod(dest_path.stat().st_mode | stat.S_IWUSR)
+        shutil.copy2(src, dest)
+
+    @staticmethod
+    def _is_ignored(path: str) -> bool:
+        name = Path(path).name
+        return any(fnmatch.fnmatch(name, pattern) for pattern in Settings.IGNORE_PATTERNS)
+
+    def _copy_one(self, src: str, dest: str) -> None:
+        if self._is_ignored(src):
+            self._say(f"ignored {abbreviate_home(src)}")
+            return
+
+        if Path(src).is_dir():
+            shutil.copytree(
+                src,
+                dest,
+                ignore=shutil.ignore_patterns(*Settings.IGNORE_PATTERNS),
+                copy_function=self._copy_file_allow_overwrite,
+                dirs_exist_ok=True,
+            )
+        else:
+            if self._is_unchanged(src, dest):
+                self._say(f"unchanged {abbreviate_home(src)}")
+                return
+            Path(dest).parent.mkdir(parents=True, exist_ok=True)
+            self._copy_file_allow_overwrite(src, dest)
+        self._say(f"copy {abbreviate_home(src)} -> {abbreviate_home(dest)}")
+
+    @staticmethod
+    def _glob_pairs(src: str, dest: str) -> list[tuple[str, str]]:
+        """The (src, dest) pairs a single-`*` entry expands to, with each star spliced into dest.
+
+        Copying and pruning have to read a pattern pair the same way: these destinations are
+        exactly the ones a backup writes, so anything else matching the dest pattern is an orphan.
+        """
+        prefix, _, suffix = src.partition("*")
+        dprefix, _, dsuffix = dest.partition("*")
+        matches = sorted(str(match) for match in Path(src).parent.glob(Path(src).name))
+        pairs = []
+        for match in matches:
+            star = match[len(prefix) : len(match) - len(suffix)]
+            pairs.append((match, f"{dprefix}{star}{dsuffix}"))
+        return pairs
+
+    def copy(self, src: str, dest: str) -> None:
+        if "*" in src:
+            pairs = self._glob_pairs(src, dest)
+            if not pairs:
+                self._say(f"no matches {abbreviate_home(src)}")
+                return
+            for match, match_dest in pairs:
+                self._copy_one(match, match_dest)
+            return
+
+        if not Path(src).exists():
+            self._say(f"not found {abbreviate_home(src)}")
+            return
+
+        self._copy_one(src, dest)
+
+    @staticmethod
+    def _walk_names(root: Path, *, follow_symlinks: bool) -> set[str]:
+        """Every path under root, relative to it, skipping ignored names.
+
+        A source is walked through its symlinked directories because backup copies them
+        dereferenced, leaving the destination holding their contents as real files; not
+        descending would read every one of those files as an orphan. A destination is not,
+        so a symlink there stays a single entry to unlink rather than a way out of the backup.
+        """
+        names: set[str] = set()
+        visited = {root.resolve()}
+        stack = [(root, "")]
+        while stack:
+            directory, prefix = stack.pop()
+            for child in directory.iterdir():
+                if Mirror._is_ignored(str(child)) or child.name in Settings.DIFF_IGNORE_PATTERNS:
+                    continue
+                relative = f"{prefix}/{child.name}" if prefix else child.name
+                names.add(relative)
+                if not child.is_dir():
+                    continue
+                if child.is_symlink():
+                    if not follow_symlinks:
+                        continue
+                    resolved = child.resolve()
+                    if resolved in visited:
+                        continue
+                    visited.add(resolved)
+                stack.append((child, relative))
+        return names
+
+    @staticmethod
+    def find_orphans(src: str, dest: str) -> list[Path]:
+        """Paths in the backup destination that no longer exist in its source.
+
+        A source that is missing or empty yields nothing: there the backup is the only
+        surviving copy, and every file in it would otherwise read as an orphan.
+        """
+        dest_path = Path(dest)
+
+        if "*" in src:
+            pairs = Mirror._glob_pairs(src, dest)
+            if not pairs:
+                return []
+            expected = {Path(pair_dest) for _, pair_dest in pairs}
+            return sorted(match for match in dest_path.parent.glob(dest_path.name) if match not in expected)
+
+        src_path = Path(src)
+        if not src_path.is_dir() or not dest_path.is_dir():
+            return []
+
+        src_names = Mirror._walk_names(src_path, follow_symlinks=True)
+        if not src_names:
+            return []
+        return sorted(dest_path / name for name in Mirror._walk_names(dest_path, follow_symlinks=False) - src_names)
+
+    def remove_orphan(self, path: Path) -> bool:
+        if path.is_symlink() or not path.is_dir():
+            path.unlink()
+            return True
+
+        # Orphans are removed deepest first, so anything left inside a directory was
+        # filtered out of the diff and never listed. Clear those, then rmdir, which
+        # still refuses any directory holding something the listing did not account for.
+        for child in path.iterdir():
+            if not self._is_ignored(str(child)):
+                continue
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+
+        try:
+            path.rmdir()
+        except OSError as error:
+            self._say(f"kept {abbreviate_home(path)}: {error.strerror}")
+            return False
+        return True
+
+
 class Formatter(argparse.HelpFormatter):
     def __init__(self, prog: str) -> None:
         super().__init__(prog, max_help_position=30)
@@ -141,6 +342,8 @@ class HAL9000:
         update_parser.set_defaults(func=self.update, passthrough=True)
 
         self.dotfiles = Dotfiles()
+        # Captures the bound method: to intercept engine messages, replace mirror or its say, not _hal_says
+        self.mirror = Mirror(say=self._hal_says)
 
         link_parser = subparsers.add_parser("link", help="move file into dotfiles and symlink it back")
         link_parser.set_defaults(func=self.link)
@@ -171,13 +374,6 @@ class HAL9000:
         if argcomplete:
             argcomplete.autocomplete(parser)
 
-    @staticmethod
-    def _abbreviate_home(path: str | Path) -> str:
-        """A single path with its home directory prefix shown as ~, for messages that name one."""
-        home = str(Path.home())
-        text = str(path)
-        return f"~{text[len(home) :]}" if text.startswith(home) else text
-
     def _hal_says(self, text: str) -> None:
         print(f"HAL: {text}")
 
@@ -185,7 +381,7 @@ class HAL9000:
         resolved = Path(path).resolve()
         allowed_roots = (Path.home(), Path(Settings.REPO_ROOT))
         if not any(resolved.is_relative_to(root) for root in allowed_roots):
-            self._hal_says(f"I'm sorry, Dave. I'm afraid I can't do that: {self._abbreviate_home(resolved)}")
+            self._hal_says(f"I'm sorry, Dave. I'm afraid I can't do that: {abbreviate_home(resolved)}")
             sys.exit(1)
 
     def _expand_template(self, path: str) -> str:
@@ -220,7 +416,7 @@ class HAL9000:
     def update(self, namespace: argparse.Namespace) -> None:
         ansible_path = shutil.which("ansible")
         if ansible_path and not ansible_path.startswith("/opt/homebrew/bin/"):
-            self._hal_says(f"Found ansible at: {self._abbreviate_home(ansible_path)}")
+            self._hal_says(f"Found ansible at: {abbreviate_home(ansible_path)}")
             self._hal_says("You should use Homebrew's ansible")
             sys.exit(1)
 
@@ -242,13 +438,13 @@ class HAL9000:
         paths = self._prepare_dotfile_entry(namespace.filename)
 
         shutil.move(paths.filepath, paths.dest_path)
-        self._hal_says(f"mv {self._abbreviate_home(paths.filepath)} -> {self._abbreviate_home(paths.dest_path)}")
+        self._hal_says(f"mv {abbreviate_home(paths.filepath)} -> {abbreviate_home(paths.dest_path)}")
 
         ln_dest = Path(paths.filepath)
         if ln_dest.is_symlink() or ln_dest.exists():
             ln_dest.unlink()
         ln_dest.symlink_to(paths.dest_path)
-        self._hal_says(f"ln {self._abbreviate_home(paths.dest_path)} -> {self._abbreviate_home(paths.filepath)}")
+        self._hal_says(f"ln {abbreviate_home(paths.dest_path)} -> {abbreviate_home(paths.filepath)}")
 
         self.dotfiles.upsert("links", paths.template_src, paths.template_dest)
 
@@ -260,20 +456,20 @@ class HAL9000:
         filepath = Path(os.path.abspath(Path(namespace.filename).expanduser()))  # noqa: PTH100 os-path-abspath
         ln_dict = next((entry for entry in self.dotfiles.data["links"] if Path(self._expand_template(entry["dest"])) == filepath), None)
         if not ln_dict:
-            self._hal_says(f"not found in manifest: {self._abbreviate_home(filepath)}")
+            self._hal_says(f"not found in manifest: {abbreviate_home(filepath)}")
             return
 
         src_path = self._expand_template(ln_dict["src"])
         dest_path = self._expand_template(ln_dict["dest"])
 
         if not Path(src_path).exists():
-            self._hal_says(f"not found in dotfiles: {self._abbreviate_home(src_path)}")
+            self._hal_says(f"not found in dotfiles: {abbreviate_home(src_path)}")
             return
 
         # A real directory at dest is one `hal sync` refused to replace, and it may hold files
         # no manifest entry covers. shutil.move would nest src inside it instead of replacing it.
         if Path(dest_path).is_dir() and not Path(dest_path).is_symlink():
-            self._hal_says(f"refusing to replace directory {self._abbreviate_home(dest_path)}")
+            self._hal_says(f"refusing to replace directory {abbreviate_home(dest_path)}")
             return
 
         if Path(dest_path).is_symlink():
@@ -289,7 +485,7 @@ class HAL9000:
         paths = self._prepare_dotfile_entry(namespace.filename)
 
         shutil.copy2(paths.filepath, paths.dest_path)
-        self._hal_says(f"cp {self._abbreviate_home(paths.filepath)} -> {self._abbreviate_home(paths.dest_path)}")
+        self._hal_says(f"cp {abbreviate_home(paths.filepath)} -> {abbreviate_home(paths.dest_path)}")
 
         self.dotfiles.upsert("copies", paths.template_src, paths.template_dest)
 
@@ -297,191 +493,13 @@ class HAL9000:
         self.dotfiles.show()
 
     def _sync_links(self, link: Entry, *, force: bool = False) -> None:
-        src = self._expand_template(link["src"])
-        if not Path(src).exists():
-            self._hal_says(f"not found {self._abbreviate_home(src)}")
-            return
-
-        dest = self._expand_template(link["dest"]).rstrip("/")
-        Path(dest).parent.mkdir(parents=True, exist_ok=True)
-
-        # If dest already exists as a real directory, remove it so the symlink replaces it.
-        # It may hold files no manifest entry covers, so make destroying them explicit.
-        if Path(dest).is_dir() and not Path(dest).is_symlink():
-            if not force:
-                self._hal_says(f"refusing to replace directory {self._abbreviate_home(dest)}, re-run with --force")
-                return
-            shutil.rmtree(dest)
-
-        dest_path = Path(dest)
-        if dest_path.is_symlink() or dest_path.exists():
-            dest_path.unlink()
-        dest_path.symlink_to(src)
-        self._hal_says(f"link {self._abbreviate_home(src)} -> {self._abbreviate_home(dest)}")
-
-    @staticmethod
-    def _is_unchanged(src: str, dest: str) -> bool:
-        """Same quick check as rsync: matching size and mtime means no rewrite needed.
-
-        Rewriting an identical file makes Dropbox and Time Machine re-examine it, so skip it.
-        """
-        dest_path = Path(dest)
-        if not dest_path.exists():
-            return False
-
-        src_stat = Path(src).stat()
-        dest_stat = dest_path.stat()
-        return src_stat.st_size == dest_stat.st_size and src_stat.st_mtime_ns == dest_stat.st_mtime_ns
-
-    @staticmethod
-    def _copy_file_allow_overwrite(src: str, dest: str) -> None:
-        if HAL9000._is_unchanged(src, dest):
-            return
-
-        dest_path = Path(dest)
-        if dest_path.exists() and not dest_path.stat().st_mode & stat.S_IWUSR:
-            dest_path.chmod(dest_path.stat().st_mode | stat.S_IWUSR)
-        shutil.copy2(src, dest)
-
-    @staticmethod
-    def _is_ignored(path: str) -> bool:
-        name = Path(path).name
-        return any(fnmatch.fnmatch(name, pattern) for pattern in Settings.IGNORE_PATTERNS)
-
-    def _copy_one(self, src: str, dest: str) -> None:
-        if self._is_ignored(src):
-            self._hal_says(f"ignored {self._abbreviate_home(src)}")
-            return
-
-        if Path(src).is_dir():
-            shutil.copytree(
-                src,
-                dest,
-                ignore=shutil.ignore_patterns(*Settings.IGNORE_PATTERNS),
-                copy_function=self._copy_file_allow_overwrite,
-                dirs_exist_ok=True,
-            )
-        else:
-            if self._is_unchanged(src, dest):
-                self._hal_says(f"unchanged {self._abbreviate_home(src)}")
-                return
-            Path(dest).parent.mkdir(parents=True, exist_ok=True)
-            self._copy_file_allow_overwrite(src, dest)
-        self._hal_says(f"copy {self._abbreviate_home(src)} -> {self._abbreviate_home(dest)}")
-
-    def _glob_pairs(self, entry: Entry) -> list[tuple[str, str]]:
-        """The (src, dest) pairs a single-`*` entry expands to, with each star spliced into dest.
-
-        Copying and pruning have to read a pattern pair the same way: these destinations are
-        exactly the ones a backup writes, so anything else matching the dest pattern is an orphan.
-        """
-        src = self._expand_template(entry["src"])
-        dest = self._expand_template(entry["dest"])
-        prefix, _, suffix = src.partition("*")
-        dprefix, _, dsuffix = dest.partition("*")
-        matches = sorted(str(match) for match in Path(src).parent.glob(Path(src).name))
-        pairs = []
-        for match in matches:
-            star = match[len(prefix) : len(match) - len(suffix)]
-            pairs.append((match, f"{dprefix}{star}{dsuffix}"))
-        return pairs
+        self.mirror.link(self._expand_template(link["src"]), self._expand_template(link["dest"]), force=force)
 
     def _copy_entry(self, entry: Entry) -> None:
-        src = self._expand_template(entry["src"])
-
-        if "*" in src:
-            pairs = self._glob_pairs(entry)
-            if not pairs:
-                self._hal_says(f"no matches {self._abbreviate_home(src)}")
-                return
-            for match, match_dest in pairs:
-                self._copy_one(match, match_dest)
-            return
-
-        if not Path(src).exists():
-            self._hal_says(f"not found {self._abbreviate_home(src)}")
-            return
-
-        dest = self._expand_template(entry["dest"])
-        self._copy_one(src, dest)
-
-    @staticmethod
-    def _walk_names(root: Path, *, follow_symlinks: bool) -> set[str]:
-        """Every path under root, relative to it, skipping ignored names.
-
-        A source is walked through its symlinked directories because backup copies them
-        dereferenced, leaving the destination holding their contents as real files; not
-        descending would read every one of those files as an orphan. A destination is not,
-        so a symlink there stays a single entry to unlink rather than a way out of the backup.
-        """
-        names: set[str] = set()
-        visited = {root.resolve()}
-        stack = [(root, "")]
-        while stack:
-            directory, prefix = stack.pop()
-            for child in directory.iterdir():
-                if HAL9000._is_ignored(str(child)) or child.name in Settings.DIFF_IGNORE_PATTERNS:
-                    continue
-                relative = f"{prefix}/{child.name}" if prefix else child.name
-                names.add(relative)
-                if not child.is_dir():
-                    continue
-                if child.is_symlink():
-                    if not follow_symlinks:
-                        continue
-                    resolved = child.resolve()
-                    if resolved in visited:
-                        continue
-                    visited.add(resolved)
-                stack.append((child, relative))
-        return names
+        self.mirror.copy(self._expand_template(entry["src"]), self._expand_template(entry["dest"]))
 
     def _find_orphans(self, entry: Entry) -> list[Path]:
-        """Paths in this entry's backup destination that no longer exist in its source.
-
-        An entry whose source is missing or empty yields nothing: there the backup is
-        the only surviving copy, and every file in it would otherwise read as an orphan.
-        """
-        src = Path(self._expand_template(entry["src"]))
-        dest = Path(self._expand_template(entry["dest"]))
-
-        if "*" in str(src):
-            pairs = self._glob_pairs(entry)
-            if not pairs:
-                return []
-            expected = {Path(pair_dest) for _, pair_dest in pairs}
-            return sorted(match for match in dest.parent.glob(dest.name) if match not in expected)
-
-        if not src.is_dir() or not dest.is_dir():
-            return []
-
-        src_names = self._walk_names(src, follow_symlinks=True)
-        if not src_names:
-            return []
-        return sorted(dest / name for name in self._walk_names(dest, follow_symlinks=False) - src_names)
-
-    def _remove_orphan(self, path: Path) -> bool:
-        if path.is_symlink() or not path.is_dir():
-            path.unlink()
-            return True
-
-        # Orphans are removed deepest first, so anything left inside a directory was
-        # filtered out of the diff and never listed. Clear those, then rmdir, which
-        # still refuses any directory holding something the listing did not account for.
-        for child in path.iterdir():
-            if not self._is_ignored(str(child)):
-                continue
-            if child.is_dir() and not child.is_symlink():
-                shutil.rmtree(child)
-            else:
-                child.unlink()
-
-        try:
-            path.rmdir()
-        except OSError as error:
-            self._hal_says(f"kept {self._abbreviate_home(path)}: {error.strerror}")
-            return False
-        return True
+        return self.mirror.find_orphans(self._expand_template(entry["src"]), self._expand_template(entry["dest"]))
 
     def _prune(self) -> None:
         orphans: list[Path] = []
@@ -489,7 +507,7 @@ class HAL9000:
             if entry.get("prune", True):
                 orphans.extend(self._find_orphans(entry))
             else:
-                self._hal_says(f"prune disabled {self._abbreviate_home(self._expand_template(entry['dest']))}")
+                self._hal_says(f"prune disabled {abbreviate_home(self._expand_template(entry['dest']))}")
 
         if not orphans:
             self._hal_says("nothing to prune")
@@ -499,7 +517,7 @@ class HAL9000:
         counted = f"{len(orphans)} orphan" if len(orphans) == 1 else f"{len(orphans)} orphans"
         self._hal_says(f"{counted} in backup, absent from source:")
         for path in orphans:
-            print(f"  {self._abbreviate_home(path)}")
+            print(f"  {abbreviate_home(path)}")
 
         try:
             answer = input(f"Delete {counted} from backup? [y/N] ")
@@ -509,7 +527,7 @@ class HAL9000:
             self._hal_says("aborted")
             return
 
-        removed = sum(self._remove_orphan(path) for path in sorted(orphans, reverse=True))
+        removed = sum(self.mirror.remove_orphan(path) for path in sorted(orphans, reverse=True))
         self._hal_says(f"pruned {removed}")
 
     @staticmethod
@@ -542,7 +560,7 @@ class HAL9000:
             return
 
         for entry in entries:
-            self._hal_says(f"{self._abbreviate_home(self._expand_template(entry['dest']))} -> {self._abbreviate_home(self._expand_template(entry['src']))}")
+            self._hal_says(f"{abbreviate_home(self._expand_template(entry['dest']))} -> {abbreviate_home(self._expand_template(entry['src']))}")
 
         try:
             answer = input("Overwrite local files with backups? [y/N] ")

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -32,7 +32,7 @@ except ImportError:
 
 def abbreviate_home(path: Path) -> str:
     home = Path.home()
-    return f"~{str(path)[len(str(home)) :]}" if path.is_relative_to(home) else str(path)
+    return f"~{str(path).removeprefix(str(home))}" if path.is_relative_to(home) else str(path)
 
 
 class PathNotAllowedError(Exception):

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -465,9 +465,6 @@ class HAL9000:
         self.dotfiles.save()
         self.dotfiles.show()
 
-    def _sync_links(self, link: Entry, *, force: bool = False) -> None:
-        self.mirror.link(self._expand_template(link["src"]), self._expand_template(link["dest"]), force=force)
-
     def _copy_entry(self, entry: Entry) -> None:
         self.mirror.copy(self._expand_template(entry["src"]), self._expand_template(entry["dest"]))
 
@@ -512,9 +509,11 @@ class HAL9000:
                 future.result()
 
     def sync(self, namespace: argparse.Namespace) -> None:
-        tasks: list[Callable[[], None]] = [functools.partial(self._sync_links, link, force=namespace.force) for link in self.dotfiles.data["links"]]
-        tasks += [functools.partial(self._copy_entry, copy) for copy in self.dotfiles.data["copies"]]
-        self._parallel(tasks)
+        # Links are metadata syscalls, so a thread pool costs more in spin-up than it saves; running them
+        # in manifest order also keeps the output stable
+        for link in self.dotfiles.data["links"]:
+            self.mirror.link(self._expand_template(link["src"]), self._expand_template(link["dest"]), force=namespace.force)
+        self._parallel(functools.partial(self._copy_entry, copy) for copy in self.dotfiles.data["copies"])
 
     def backup(self, namespace: argparse.Namespace) -> None:
         self._parallel(functools.partial(self._copy_entry, entry) for entry in self.dotfiles.data["backups"])

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -57,19 +57,19 @@ class Entry(TypedDict):
 
 
 class DotfilePaths(NamedTuple):
-    filepath: str
-    dest_path: str
+    filepath: Path
+    dest_path: Path
     template_src: str
     template_dest: str
 
 
 class Dotfiles:
-    DEFAULT_CONFIG: str = str(Settings.DOTFILES_ROOT / "hal_dotfiles.json")
+    DEFAULT_CONFIG: Path = Settings.DOTFILES_ROOT / "hal_dotfiles.json"
     # Keys are written back in this order; any other key follows them, sorted by name
     ENTRY_KEY_ORDER: tuple[str, ...] = ("src", "dest", "prune")
 
-    def __init__(self, path: str | None = None) -> None:
-        self.path: str = path or self.DEFAULT_CONFIG
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path: Path = Path(path) if path else self.DEFAULT_CONFIG
         self._data: dict[str, list[Entry]] | None = None
 
     @property
@@ -80,7 +80,7 @@ class Dotfiles:
 
     def _load(self) -> dict[str, list[Entry]]:
         try:
-            with Path(self.path).open() as f:
+            with self.path.open() as f:
                 return json.load(f)
         except FileNotFoundError:
             return {"backups": [], "copies": [], "links": []}
@@ -113,7 +113,7 @@ class Dotfiles:
         # Read before opening for write: opening truncates, and data loads lazily,
         # so building the payload inside the with block would read back an empty file
         ordered_data = self._ordered_data()
-        with Path(self.path).open("w") as f:
+        with self.path.open("w") as f:
             json.dump(ordered_data, f, indent=2, separators=(",", ": "))
 
 
@@ -122,30 +122,29 @@ class Mirror:
     def __init__(self, say: Callable[[str], None]) -> None:
         self._say = say
 
-    def link(self, src: str, dest: str, *, force: bool = False) -> None:
-        if not Path(src).exists():
+    def link(self, src: Path, dest: Path, *, force: bool = False) -> None:
+        if not src.exists():
             self._say(f"not found {abbreviate_home(src)}")
             return
 
-        dest = dest.rstrip("/")
-        Path(dest).parent.mkdir(parents=True, exist_ok=True)
+        dest.parent.mkdir(parents=True, exist_ok=True)
 
         # If dest already exists as a real directory, remove it so the symlink replaces it.
         # It may hold files no manifest entry covers, so make destroying them explicit.
-        if Path(dest).is_dir() and not Path(dest).is_symlink():
+        if dest.is_dir() and not dest.is_symlink():
             if not force:
                 self._say(f"refusing to replace directory {abbreviate_home(dest)}, re-run with --force")
                 return
             shutil.rmtree(dest)
 
-        dest_path = Path(dest)
-        if dest_path.is_symlink() or dest_path.exists():
-            dest_path.unlink()
-        dest_path.symlink_to(src)
+        if dest.is_symlink() or dest.exists():
+            dest.unlink()
+        dest.symlink_to(src)
         self._say(f"link {abbreviate_home(src)} -> {abbreviate_home(dest)}")
 
+    # str as well as Path: shutil.copytree hands its copy_function plain strings
     @staticmethod
-    def _is_unchanged(src: str, dest: str) -> bool:
+    def _is_unchanged(src: str | Path, dest: str | Path) -> bool:
         dest_path = Path(dest)
         if not dest_path.exists():
             return False
@@ -156,7 +155,7 @@ class Mirror:
         return src_stat.st_size == dest_stat.st_size and src_stat.st_mtime_ns == dest_stat.st_mtime_ns
 
     @staticmethod
-    def _copy_file_allow_overwrite(src: str, dest: str) -> None:
+    def _copy_file_allow_overwrite(src: str | Path, dest: str | Path) -> None:
         if Mirror._is_unchanged(src, dest):
             return
 
@@ -166,16 +165,15 @@ class Mirror:
         shutil.copy2(src, dest)
 
     @staticmethod
-    def _is_ignored(path: str, patterns: tuple[str, ...]) -> bool:
-        name = Path(path).name
-        return any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
+    def _is_ignored(path: Path, patterns: tuple[str, ...]) -> bool:
+        return any(fnmatch.fnmatch(path.name, pattern) for pattern in patterns)
 
-    def _copy_one(self, src: str, dest: str) -> None:
+    def _copy_one(self, src: Path, dest: Path) -> None:
         if self._is_ignored(src, Settings.IGNORE_PATTERNS):
             self._say(f"ignored {abbreviate_home(src)}")
             return
 
-        if Path(src).is_dir():
+        if src.is_dir():
             shutil.copytree(
                 src,
                 dest,
@@ -187,25 +185,25 @@ class Mirror:
             if self._is_unchanged(src, dest):
                 self._say(f"unchanged {abbreviate_home(src)}")
                 return
-            Path(dest).parent.mkdir(parents=True, exist_ok=True)
+            dest.parent.mkdir(parents=True, exist_ok=True)
             self._copy_file_allow_overwrite(src, dest)
         self._say(f"copy {abbreviate_home(src)} -> {abbreviate_home(dest)}")
 
     @staticmethod
-    def _glob_pairs(src: str, dest: str) -> list[tuple[str, str]]:
+    def _glob_pairs(src: Path, dest: Path) -> list[tuple[Path, Path]]:
         # Shared by copy and find_orphans so both read a pattern pair the same way: these destinations are
         # exactly the ones a backup writes, so anything else matching the dest pattern is an orphan
-        prefix, _, suffix = src.partition("*")
-        dprefix, _, dsuffix = dest.partition("*")
-        matches = sorted(str(match) for match in Path(src).parent.glob(Path(src).name))
+        prefix, _, suffix = str(src).partition("*")
+        dprefix, _, dsuffix = str(dest).partition("*")
         pairs = []
-        for match in matches:
-            star = match[len(prefix) : len(match) - len(suffix)]
-            pairs.append((match, f"{dprefix}{star}{dsuffix}"))
+        for match in sorted(src.parent.glob(src.name), key=str):
+            text = str(match)
+            star = text[len(prefix) : len(text) - len(suffix)]
+            pairs.append((match, Path(f"{dprefix}{star}{dsuffix}")))
         return pairs
 
-    def copy(self, src: str, dest: str) -> None:
-        if "*" in src:
+    def copy(self, src: Path, dest: Path) -> None:
+        if "*" in str(src):
             pairs = self._glob_pairs(src, dest)
             if not pairs:
                 self._say(f"no matches {abbreviate_home(src)}")
@@ -214,7 +212,7 @@ class Mirror:
                 self._copy_one(match, match_dest)
             return
 
-        if not Path(src).exists():
+        if not src.exists():
             self._say(f"not found {abbreviate_home(src)}")
             return
 
@@ -228,7 +226,7 @@ class Mirror:
         while stack:
             directory, prefix = stack.pop()
             for child in directory.iterdir():
-                if Mirror._is_ignored(str(child), Settings.IGNORE_PATTERNS + Settings.DIFF_IGNORE_PATTERNS):
+                if Mirror._is_ignored(child, Settings.IGNORE_PATTERNS + Settings.DIFF_IGNORE_PATTERNS):
                     continue
                 relative = f"{prefix}/{child.name}" if prefix else child.name
                 names.add(relative)
@@ -248,25 +246,22 @@ class Mirror:
         return names
 
     @staticmethod
-    def find_orphans(src: str, dest: str) -> list[Path]:
-        dest_path = Path(dest)
-
-        if "*" in src:
+    def find_orphans(src: Path, dest: Path) -> list[Path]:
+        if "*" in str(src):
             pairs = Mirror._glob_pairs(src, dest)
             if not pairs:
                 return []
-            expected = {Path(pair_dest) for _, pair_dest in pairs}
-            return sorted(match for match in dest_path.parent.glob(dest_path.name) if match not in expected)
+            expected = {pair_dest for _, pair_dest in pairs}
+            return sorted(match for match in dest.parent.glob(dest.name) if match not in expected)
 
-        src_path = Path(src)
         # A missing or empty source means the backup is the only surviving copy, and every file in it would read as an orphan
-        if not src_path.is_dir() or not dest_path.is_dir():
+        if not src.is_dir() or not dest.is_dir():
             return []
 
-        src_names = Mirror._walk_names(src_path, follow_symlinks=True)
+        src_names = Mirror._walk_names(src, follow_symlinks=True)
         if not src_names:
             return []
-        return sorted(dest_path / name for name in Mirror._walk_names(dest_path, follow_symlinks=False) - src_names)
+        return sorted(dest / name for name in Mirror._walk_names(dest, follow_symlinks=False) - src_names)
 
     def remove_orphan(self, path: Path) -> bool:
         if path.is_symlink() or not path.is_dir():
@@ -277,7 +272,7 @@ class Mirror:
         # filtered out of the diff and never listed. Clear those, then rmdir, which
         # still refuses any directory holding something the listing did not account for.
         for child in path.iterdir():
-            if not self._is_ignored(str(child), Settings.IGNORE_PATTERNS):
+            if not self._is_ignored(child, Settings.IGNORE_PATTERNS):
                 continue
             if child.is_dir() and not child.is_symlink():
                 shutil.rmtree(child)
@@ -357,32 +352,34 @@ class HAL9000:
     def _hal_says(self, text: str) -> None:
         print(f"HAL: {text}")
 
-    def _validate_path(self, path: str) -> None:
-        resolved = Path(path).resolve()
+    def _validate_path(self, path: Path) -> None:
+        resolved = path.resolve()
         allowed_roots = (Path.home(), Settings.REPO_ROOT)
         if not any(resolved.is_relative_to(root) for root in allowed_roots):
             raise PathNotAllowedError(abbreviate_home(resolved))
 
-    def _expand_template(self, path: str) -> str:
-        expanded = path.replace("{{HOME}}", str(Path.home())).replace("{{REPO_ROOT}}", str(Settings.REPO_ROOT))
+    def _expand_template(self, path: str) -> Path:
+        expanded = Path(path.replace("{{HOME}}", str(Path.home())).replace("{{REPO_ROOT}}", str(Settings.REPO_ROOT)))
         self._validate_path(expanded)
         return expanded
 
     def _prepare_dotfile_entry(self, filename: str) -> DotfilePaths:
-        filepath = str((Path.cwd() / filename).resolve())
+        filepath = (Path.cwd() / filename).resolve()
         self._validate_path(filepath)
 
-        home = str(Path.home())
-        relative_path = str(Path(filepath).relative_to(home)) if filepath.startswith(home) else Path(filepath).name
+        home = Path.home()
+        if filepath.is_relative_to(home):
+            relative_path = filepath.relative_to(home)
+            template_dest = str(Path("{{HOME}}") / relative_path)
+        else:
+            relative_path = Path(filepath.name)
+            template_dest = str(filepath)
 
-        dest_path = str(Settings.DOTFILES_ROOT / relative_path)
-        dest_dir = Path(dest_path).parent
+        dest_path = Settings.DOTFILES_ROOT / relative_path
+        if dest_path.parent != Settings.DOTFILES_ROOT:
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if dest_dir != Settings.DOTFILES_ROOT:
-            dest_dir.mkdir(parents=True, exist_ok=True)
-
-        template_src = dest_path.replace(str(Settings.REPO_ROOT), "{{REPO_ROOT}}")
-        template_dest = filepath.replace(home, "{{HOME}}")
+        template_src = str(Path("{{REPO_ROOT}}") / dest_path.relative_to(Settings.REPO_ROOT))
 
         return DotfilePaths(filepath, dest_path, template_src, template_dest)
 
@@ -419,10 +416,9 @@ class HAL9000:
         shutil.move(paths.filepath, paths.dest_path)
         self._hal_says(f"mv {abbreviate_home(paths.filepath)} -> {abbreviate_home(paths.dest_path)}")
 
-        ln_dest = Path(paths.filepath)
-        if ln_dest.is_symlink() or ln_dest.exists():
-            ln_dest.unlink()
-        ln_dest.symlink_to(paths.dest_path)
+        if paths.filepath.is_symlink() or paths.filepath.exists():
+            paths.filepath.unlink()
+        paths.filepath.symlink_to(paths.dest_path)
         self._hal_says(f"ln {abbreviate_home(paths.dest_path)} -> {abbreviate_home(paths.filepath)}")
 
         self.dotfiles.upsert("links", paths.template_src, paths.template_dest)
@@ -433,7 +429,7 @@ class HAL9000:
     def unlink(self, namespace: argparse.Namespace) -> None:
         # abspath, not Path.resolve(): the path at dest IS the symlink this removes, and resolving it would land inside the dotfiles repo
         filepath = Path(os.path.abspath(Path(namespace.filename).expanduser()))  # noqa: PTH100 os-path-abspath
-        ln_dict = next((entry for entry in self.dotfiles.data["links"] if Path(self._expand_template(entry["dest"])) == filepath), None)
+        ln_dict = next((entry for entry in self.dotfiles.data["links"] if self._expand_template(entry["dest"]) == filepath), None)
         if not ln_dict:
             self._hal_says(f"not found in manifest: {abbreviate_home(filepath)}")
             return
@@ -441,18 +437,18 @@ class HAL9000:
         src_path = self._expand_template(ln_dict["src"])
         dest_path = self._expand_template(ln_dict["dest"])
 
-        if not Path(src_path).exists():
+        if not src_path.exists():
             self._hal_says(f"not found in dotfiles: {abbreviate_home(src_path)}")
             return
 
         # A real directory at dest is one `hal sync` refused to replace, and it may hold files
         # no manifest entry covers. shutil.move would nest src inside it instead of replacing it.
-        if Path(dest_path).is_dir() and not Path(dest_path).is_symlink():
+        if dest_path.is_dir() and not dest_path.is_symlink():
             self._hal_says(f"refusing to replace directory {abbreviate_home(dest_path)}")
             return
 
-        if Path(dest_path).is_symlink():
-            Path(dest_path).unlink()
+        if dest_path.is_symlink():
+            dest_path.unlink()
         shutil.move(src_path, dest_path)
 
         self.dotfiles.remove("links", ln_dict)

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -13,7 +13,7 @@ import stat
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -47,8 +47,7 @@ class Entry(TypedDict):
 
 class Dotfiles:
     DEFAULT_CONFIG: str = str(Path(Settings.DOTFILES_ROOT) / "hal_dotfiles.json")
-    # save() rebuilds every entry from these keys, so a key missing here is dropped
-    # from the manifest the next time any command writes it back
+    # Keys are written back in this order; any other key follows them, sorted by name
     ENTRY_KEY_ORDER: tuple[str, ...] = ("src", "dest", "prune")
 
     def __init__(self, path: str | None = None) -> None:
@@ -81,9 +80,11 @@ class Dotfiles:
 
     @staticmethod
     def _ordered_entry(entry: Entry) -> dict[str, object]:
-        # Projected through ENTRY_KEY_ORDER by keys held in a variable, which a TypedDict cannot be subscripted with
-        fields = cast("dict[str, object]", entry)
-        return {key: fields[key] for key in Dotfiles.ENTRY_KEY_ORDER if key in fields}
+        """The entry with its keys in ENTRY_KEY_ORDER, any other key after them by name."""
+        fields = dict(entry.items())
+        known = [key for key in Dotfiles.ENTRY_KEY_ORDER if key in fields]
+        unknown = sorted(key for key in fields if key not in Dotfiles.ENTRY_KEY_ORDER)
+        return {key: fields[key] for key in [*known, *unknown]}
 
     def _ordered_data(self) -> dict[str, list[dict[str, object]]]:
         """The manifest as written back to disk, so plain mappings rather than Entry values."""

--- a/bin/hal.py
+++ b/bin/hal.py
@@ -41,8 +41,8 @@ class PathNotAllowedError(Exception):
 
 
 class Settings:
-    REPO_ROOT: str = str(Path(__file__).resolve().parent.parent)
-    DOTFILES_ROOT: str = str(Path(REPO_ROOT) / "dotfiles")
+    REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+    DOTFILES_ROOT: Path = REPO_ROOT / "dotfiles"
     IGNORE_PATTERNS: tuple[str, ...] = (".DS_Store", ".venv", ".*_cache", "__pycache__", "node_modules", "-private-tmp*")
     # Skipped when diffing a backup against its source, but still copied by backup itself:
     # git reclaims loose objects and packs locally, so a copy-only backup keeps every
@@ -64,7 +64,7 @@ class DotfilePaths(NamedTuple):
 
 
 class Dotfiles:
-    DEFAULT_CONFIG: str = str(Path(Settings.DOTFILES_ROOT) / "hal_dotfiles.json")
+    DEFAULT_CONFIG: str = str(Settings.DOTFILES_ROOT / "hal_dotfiles.json")
     # Keys are written back in this order; any other key follows them, sorted by name
     ENTRY_KEY_ORDER: tuple[str, ...] = ("src", "dest", "prune")
 
@@ -359,12 +359,12 @@ class HAL9000:
 
     def _validate_path(self, path: str) -> None:
         resolved = Path(path).resolve()
-        allowed_roots = (Path.home(), Path(Settings.REPO_ROOT))
+        allowed_roots = (Path.home(), Settings.REPO_ROOT)
         if not any(resolved.is_relative_to(root) for root in allowed_roots):
             raise PathNotAllowedError(abbreviate_home(resolved))
 
     def _expand_template(self, path: str) -> str:
-        expanded = path.replace("{{HOME}}", str(Path.home())).replace("{{REPO_ROOT}}", Settings.REPO_ROOT)
+        expanded = path.replace("{{HOME}}", str(Path.home())).replace("{{REPO_ROOT}}", str(Settings.REPO_ROOT))
         self._validate_path(expanded)
         return expanded
 
@@ -375,18 +375,18 @@ class HAL9000:
         home = str(Path.home())
         relative_path = str(Path(filepath).relative_to(home)) if filepath.startswith(home) else Path(filepath).name
 
-        dest_path = str(Path(Settings.DOTFILES_ROOT) / relative_path)
-        dest_dir = str(Path(dest_path).parent)
+        dest_path = str(Settings.DOTFILES_ROOT / relative_path)
+        dest_dir = Path(dest_path).parent
 
         if dest_dir != Settings.DOTFILES_ROOT:
-            Path(dest_dir).mkdir(parents=True, exist_ok=True)
+            dest_dir.mkdir(parents=True, exist_ok=True)
 
-        template_src = dest_path.replace(Settings.REPO_ROOT, "{{REPO_ROOT}}")
+        template_src = dest_path.replace(str(Settings.REPO_ROOT), "{{REPO_ROOT}}")
         template_dest = filepath.replace(home, "{{HOME}}")
 
         return DotfilePaths(filepath, dest_path, template_src, template_dest)
 
-    def _run(self, command: str, *, cwd: str | None = None, verbose: bool = True) -> int:
+    def _run(self, command: str, *, cwd: Path | None = None, verbose: bool = True) -> int:
         if verbose:
             self._hal_says(command)
 
@@ -404,7 +404,7 @@ class HAL9000:
         if returncode != 0:
             sys.exit(returncode)
 
-        playbooks_dir = str(Path(Settings.REPO_ROOT) / "playbooks")
+        playbooks_dir = Settings.REPO_ROOT / "playbooks"
         command = "ansible-playbook site.yml -v"
         if namespace.extra_args:
             command = " ".join([command, *(shlex.quote(arg) for arg in namespace.extra_args)])
@@ -550,7 +550,7 @@ class HAL9000:
     def open_the_pod_bay_doors(self, namespace: argparse.Namespace) -> None:  # noqa: ARG002 unused-method-argument
         self._hal_says("I'm sorry Dave, I'm afraid I can't do that.")
 
-        filepath = str(Path(Settings.REPO_ROOT) / "assets" / "im-sorry-dave-im-afraid-i-cant-do-that.mp3")
+        filepath = str(Settings.REPO_ROOT / "assets" / "im-sorry-dave-im-afraid-i-cant-do-that.mp3")
         self._run(f"afplay {shlex.quote(filepath)}", verbose=False)
 
     def read_lips(self) -> None:

--- a/dotfiles/.hal_completion.zsh
+++ b/dotfiles/.hal_completion.zsh
@@ -16,8 +16,7 @@ _hal() {
         'update:pull repo and run ansible-playbook (extra args pass through, e.g. --tags python,node)'
         'link:move file into dotfiles and symlink it back'
         'unlink:move file back from dotfiles and remove symlink'
-        'copy:copy file into dotfiles (no symlink)'
-        'sync:sync all links and copies'
+        'sync:sync all links'
         'backup:back up all backup entries to their destinations'
         'restore:restore all backup entries, overwriting local files'
         'open-the-pod-bay-doors:open the pod bay doors, please, HAL'
@@ -38,7 +37,7 @@ _hal() {
                     '--tags[only run plays and tasks tagged with these values]:tags:_hal_tags' \
                     '--skip-tags[skip plays and tasks whose tags match these values]:tags:_hal_tags'
                 ;;
-            link|unlink|copy)
+            link|unlink)
                 _arguments \
                     '(-h --help)'{-h,--help}'[show this help message and exit]' \
                     ':filename:_files'

--- a/dotfiles/hal_dotfiles.json
+++ b/dotfiles/hal_dotfiles.json
@@ -62,7 +62,6 @@
       "dest": "{{HOME}}/Dropbox/Projects/*.code-workspace"
     }
   ],
-  "copies": [],
   "links": [
     {
       "src": "{{REPO_ROOT}}/dotfiles/.hal_completion.zsh",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dev = [
     { include-group = "test" },
     { include-group = "lint" },
     { include-group = "audit" },
-    "argcomplete>=3.7.0",
 ]
 
 [tool.uv]

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -8,6 +8,16 @@ from unittest.mock import patch
 import pytest
 
 
+class TestAbbreviateHome:
+    def test_only_paths_under_home_are_abbreviated(self, hal_module, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        monkeypatch.setattr(Path, "home", lambda: home)
+
+        assert hal_module.abbreviate_home(home) == "~"
+        assert hal_module.abbreviate_home(home / ".zshrc") == "~/.zshrc"
+        assert hal_module.abbreviate_home(tmp_path / "homely" / "x") == str(tmp_path / "homely" / "x")
+
+
 class TestDotfilesLoad:
     def test_missing_manifest_loads_as_empty(self, hal_module, tmp_path):
         dotfiles = hal_module.Dotfiles(str(tmp_path / "hal_dotfiles.json"))

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -472,8 +472,8 @@ class TestMirror:
         assert hal_module.Mirror.find_orphans(src, dest) == [dest / "gone.txt"]
 
 
-class TestSyncLinks:
-    """_sync_links never destroys a real directory unless forced."""
+class TestMirrorLink:
+    """Mirror.link never destroys a real directory unless forced."""
 
     def test_refuses_to_replace_real_directory(self, hal_instance, tmp_path):
         """A real directory at dest is left alone, so unmanaged files survive."""
@@ -485,8 +485,7 @@ class TestSyncLinks:
         dest.mkdir()
         (dest / "unmanaged.md").write_text("preserve me")
 
-        with patch.object(hal_instance, "_expand_template", side_effect=Path):
-            hal_instance._sync_links({"src": str(src), "dest": str(dest)})
+        hal_instance.mirror.link(src, dest)
 
         assert not dest.is_symlink()
         assert (dest / "unmanaged.md").read_text() == "preserve me"
@@ -501,8 +500,7 @@ class TestSyncLinks:
         dest.mkdir()
         (dest / "unmanaged.md").write_text("discard me")
 
-        with patch.object(hal_instance, "_expand_template", side_effect=Path):
-            hal_instance._sync_links({"src": str(src), "dest": str(dest)}, force=True)
+        hal_instance.mirror.link(src, dest, force=True)
 
         assert dest.is_symlink()
         assert dest.resolve() == src.resolve()
@@ -515,8 +513,7 @@ class TestSyncLinks:
         dest = tmp_path / "dest.txt"
         dest.write_text("pre-existing")
 
-        with patch.object(hal_instance, "_expand_template", side_effect=Path):
-            hal_instance._sync_links({"src": str(src), "dest": str(dest)})
+        hal_instance.mirror.link(src, dest)
 
         assert dest.is_symlink()
         assert dest.read_text() == "from repo"
@@ -532,8 +529,7 @@ class TestSyncLinks:
         dest = tmp_path / "dest"
         dest.symlink_to(stale)
 
-        with patch.object(hal_instance, "_expand_template", side_effect=Path):
-            hal_instance._sync_links({"src": str(src), "dest": str(dest)})
+        hal_instance.mirror.link(src, dest)
 
         assert dest.is_symlink()
         assert dest.resolve() == src.resolve()

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -228,7 +228,7 @@ class TestUpdateAnsibleCheck:
         ns = argparse.Namespace(func=hal_instance.update, extra_args=[])
         hal_instance.update(ns)
 
-        assert "git fetch" in commands_run
+        assert "git pull" in commands_run
 
 
 class TestUpdateWorkingDirectory:
@@ -250,7 +250,6 @@ class TestUpdateWorkingDirectory:
 
         repo_root = hal_module.Settings.REPO_ROOT
         assert commands_run == [
-            ("git fetch", repo_root),
             ("git pull", repo_root),
             ("ansible-playbook site.yml -v", repo_root / "playbooks"),
         ]

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -883,20 +883,21 @@ class TestCopyEntryGlob:
         assert (local_dir / "acme.code-workspace").read_text() == "backed up"
 
 
-class TestParallel:
-    """_parallel runs every task and re-raises the first failure only after the others have finished."""
+class TestCopyEntries:
+    """_copy_entries copies every entry and re-raises the first failure only after the others have finished."""
 
-    def test_failure_is_reraised_after_the_other_tasks_ran(self, hal_module):
+    def test_failure_is_reraised_after_the_other_entries_ran(self, hal_instance):
         finished = []
 
-        def fail():
-            raise RuntimeError
+        def copy_entry(entry):
+            if entry["src"] == "fail":
+                raise RuntimeError
+            finished.append(entry["src"])
 
-        def succeed():
-            finished.append("ok")
+        hal_instance._copy_entry = copy_entry
 
         with pytest.raises(RuntimeError):
-            hal_module.HAL9000._parallel([fail, succeed])
+            hal_instance._copy_entries([{"src": "fail", "dest": "d"}, {"src": "ok", "dest": "d"}])
 
         assert finished == ["ok"]
 

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -91,20 +91,16 @@ class TestValidatePath:
 
 
 class TestUpdateSanitization:
-    def test_extra_args_are_quoted(self, hal_instance):
+    def test_extra_args_are_quoted(self, hal_instance, monkeypatch):
         """extra_args with shell metacharacters must be quoted."""
         commands_run = []
 
-        def mock_run(command, *, shell=True, verbose=True):  # noqa: ARG001 unused-function-argument
+        def mock_run(command, *, verbose=True):  # noqa: ARG001 unused-function-argument
             commands_run.append(command)
             return 0
 
-        def mock_run_with_output(command, *, shell=True, verbose=True, print_output=True):  # noqa: ARG001 unused-function-argument
-            commands_run.append(command)
-            return 0, b"/opt/homebrew/bin/ansible\n"
-
+        monkeypatch.setattr("shutil.which", lambda _cmd: "/opt/homebrew/bin/ansible")
         hal_instance._run = mock_run
-        hal_instance._run_with_output = mock_run_with_output
 
         ns = argparse.Namespace(func=hal_instance.update)
         hal_instance.update(ns, extra_args=["--tags", "foo;rm -rf ~"])
@@ -117,18 +113,24 @@ class TestUpdateFailurePropagation:
     """update exits non-zero when git pull or the playbook run fails."""
 
     @staticmethod
-    def _install_mocks(hal_instance, failing_command):
-        def mock_run(command, *, shell=True, verbose=True):  # noqa: ARG001 unused-function-argument
+    def _install_mocks(hal_instance, monkeypatch, failing_command):
+        def mock_run(command, *, verbose=True):  # noqa: ARG001 unused-function-argument
             return 1 if failing_command in command else 0
 
-        def mock_run_with_output(command, *, shell=True, verbose=True, print_output=True):  # noqa: ARG001 unused-function-argument
-            return 0, b"/opt/homebrew/bin/ansible\n"
-
+        monkeypatch.setattr("shutil.which", lambda _cmd: "/opt/homebrew/bin/ansible")
         hal_instance._run = mock_run
-        hal_instance._run_with_output = mock_run_with_output
 
-    def test_git_pull_failure_exits(self, hal_instance):
-        self._install_mocks(hal_instance, "git pull")
+    def test_git_pull_failure_exits(self, hal_instance, monkeypatch):
+        self._install_mocks(hal_instance, monkeypatch, "git pull")
+
+        ns = argparse.Namespace(func=hal_instance.update)
+        with pytest.raises(SystemExit) as excinfo:
+            hal_instance.update(ns)
+
+        assert excinfo.value.code == 1
+
+    def test_playbook_failure_exits(self, hal_instance, monkeypatch):
+        self._install_mocks(hal_instance, monkeypatch, "ansible-playbook")
 
         ns = argparse.Namespace(func=hal_instance.update)
         with pytest.raises(SystemExit) as excinfo:
@@ -136,14 +138,41 @@ class TestUpdateFailurePropagation:
 
         assert excinfo.value.code == 1
 
-    def test_playbook_failure_exits(self, hal_instance):
-        self._install_mocks(hal_instance, "ansible-playbook")
+
+class TestUpdateAnsibleCheck:
+    """update refuses a non-Homebrew ansible before touching git, and skips the check when none is installed."""
+
+    def test_non_homebrew_ansible_exits(self, hal_instance, monkeypatch):
+        commands_run = []
+
+        def mock_run(command, *, verbose=True):  # noqa: ARG001 unused-function-argument
+            commands_run.append(command)
+            return 0
+
+        monkeypatch.setattr("shutil.which", lambda _cmd: "/usr/local/bin/ansible")
+        hal_instance._run = mock_run
 
         ns = argparse.Namespace(func=hal_instance.update)
         with pytest.raises(SystemExit) as excinfo:
             hal_instance.update(ns)
 
         assert excinfo.value.code == 1
+        assert commands_run == []
+
+    def test_missing_ansible_skips_check(self, hal_instance, monkeypatch):
+        commands_run = []
+
+        def mock_run(command, *, verbose=True):  # noqa: ARG001 unused-function-argument
+            commands_run.append(command)
+            return 0
+
+        monkeypatch.setattr("shutil.which", lambda _cmd: None)
+        hal_instance._run = mock_run
+
+        ns = argparse.Namespace(func=hal_instance.update)
+        hal_instance.update(ns)
+
+        assert "git fetch" in commands_run
 
 
 class TestUserFilenameValidation:

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -109,7 +109,7 @@ class TestValidatePath:
         home = (tmp_path / "home").resolve()
         with (
             patch("pathlib.Path.home", return_value=home),
-            patch.object(hal_module.Settings, "REPO_ROOT", str((tmp_path / "repo").resolve())),
+            patch.object(hal_module.Settings, "REPO_ROOT", (tmp_path / "repo").resolve()),
         ):
             hal_instance._validate_path(f"{home}/inside/stuff")
             with pytest.raises(hal_module.PathNotAllowedError):
@@ -119,7 +119,7 @@ class TestValidatePath:
         repo_root = (tmp_path / "repo").resolve()
         with (
             patch("pathlib.Path.home", return_value=(tmp_path / "home").resolve()),
-            patch.object(hal_module.Settings, "REPO_ROOT", str(repo_root)),
+            patch.object(hal_module.Settings, "REPO_ROOT", repo_root),
         ):
             hal_instance._validate_path(f"{repo_root}/inside/stuff")
             with pytest.raises(hal_module.PathNotAllowedError):
@@ -242,7 +242,7 @@ class TestUpdateWorkingDirectory:
         assert commands_run == [
             ("git fetch", repo_root),
             ("git pull", repo_root),
-            ("ansible-playbook site.yml -v", str(Path(repo_root) / "playbooks")),
+            ("ansible-playbook site.yml -v", repo_root / "playbooks"),
         ]
         assert Path.cwd() == cwd_before
 
@@ -266,8 +266,8 @@ class TestPrepareDotfileEntry:
         (home / ".config" / "app.toml").write_text("x")
         repo = tmp_path / "repo"
         monkeypatch.setattr(Path, "home", lambda: home)
-        monkeypatch.setattr(hal_module.Settings, "REPO_ROOT", str(repo))
-        monkeypatch.setattr(hal_module.Settings, "DOTFILES_ROOT", str(repo / "dotfiles"))
+        monkeypatch.setattr(hal_module.Settings, "REPO_ROOT", repo)
+        monkeypatch.setattr(hal_module.Settings, "DOTFILES_ROOT", repo / "dotfiles")
         monkeypatch.chdir(home)
 
         paths = hal_instance._prepare_dotfile_entry(".config/app.toml")

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -75,22 +75,22 @@ class TestDotfilesMutation:
 class TestValidatePath:
     def test_valid_path_under_home(self, hal_instance):
         home = str(Path.home())
-        path = f"{home}/.zshrc"
+        path = Path(f"{home}/.zshrc")
         hal_instance._validate_path(path)
 
     def test_valid_path_under_repo_root(self, hal_instance, hal_module):
-        path = f"{hal_module.Settings.REPO_ROOT}/dotfiles/.zshrc"
+        path = Path(f"{hal_module.Settings.REPO_ROOT}/dotfiles/.zshrc")
         hal_instance._validate_path(path)
 
     def test_path_traversal_outside_home(self, hal_instance, hal_module):
         home = str(Path.home())
-        path = f"{home}/../../etc/passwd"
+        path = Path(f"{home}/../../etc/passwd")
         with pytest.raises(hal_module.PathNotAllowedError):
             hal_instance._validate_path(path)
 
     def test_path_to_etc(self, hal_instance, hal_module):
         with pytest.raises(hal_module.PathNotAllowedError):
-            hal_instance._validate_path("/etc/crontab")
+            hal_instance._validate_path(Path("/etc/crontab"))
 
     def test_path_traversal_in_template_expansion(self, hal_instance, hal_module):
         with pytest.raises(hal_module.PathNotAllowedError):
@@ -98,7 +98,7 @@ class TestValidatePath:
 
     def test_normal_template_expansion(self, hal_instance):
         result = hal_instance._expand_template("{{HOME}}/.zshrc")
-        assert result == f"{Path.home()}/.zshrc"
+        assert result == Path.home() / ".zshrc"
 
     def test_sibling_directory_sharing_home_prefix(self, hal_instance, hal_module, tmp_path):
         """A sibling whose name merely starts with the home directory's name is not under it.
@@ -111,9 +111,9 @@ class TestValidatePath:
             patch("pathlib.Path.home", return_value=home),
             patch.object(hal_module.Settings, "REPO_ROOT", (tmp_path / "repo").resolve()),
         ):
-            hal_instance._validate_path(f"{home}/inside/stuff")
+            hal_instance._validate_path(Path(f"{home}/inside/stuff"))
             with pytest.raises(hal_module.PathNotAllowedError):
-                hal_instance._validate_path(f"{home}-elsewhere/stuff")
+                hal_instance._validate_path(Path(f"{home}-elsewhere/stuff"))
 
     def test_sibling_directory_sharing_repo_root_prefix(self, hal_instance, hal_module, tmp_path):
         repo_root = (tmp_path / "repo").resolve()
@@ -121,12 +121,12 @@ class TestValidatePath:
             patch("pathlib.Path.home", return_value=(tmp_path / "home").resolve()),
             patch.object(hal_module.Settings, "REPO_ROOT", repo_root),
         ):
-            hal_instance._validate_path(f"{repo_root}/inside/stuff")
+            hal_instance._validate_path(Path(f"{repo_root}/inside/stuff"))
             with pytest.raises(hal_module.PathNotAllowedError):
-                hal_instance._validate_path(f"{repo_root}-elsewhere/stuff")
+                hal_instance._validate_path(Path(f"{repo_root}-elsewhere/stuff"))
 
     def test_home_itself_is_valid(self, hal_instance):
-        hal_instance._validate_path(str(Path.home()))
+        hal_instance._validate_path(Path.home())
 
     def test_copy_entry_rejects_an_unsafe_dest_even_when_src_is_missing(self, hal_instance, hal_module, tmp_path, monkeypatch):
         """Both paths of an entry are expanded and checked before the engine looks at either."""
@@ -273,11 +273,27 @@ class TestPrepareDotfileEntry:
         paths = hal_instance._prepare_dotfile_entry(".config/app.toml")
 
         assert paths == hal_module.DotfilePaths(
-            filepath=str(home / ".config" / "app.toml"),
-            dest_path=str(repo / "dotfiles" / ".config" / "app.toml"),
+            filepath=home / ".config" / "app.toml",
+            dest_path=repo / "dotfiles" / ".config" / "app.toml",
             template_src="{{REPO_ROOT}}/dotfiles/.config/app.toml",
             template_dest="{{HOME}}/.config/app.toml",
         )
+
+    def test_sibling_of_home_is_not_treated_as_inside_it(self, hal_instance, hal_module, tmp_path, monkeypatch):
+        """A path that merely shares home's prefix is outside it, so it lands under dotfiles/ by bare name."""
+        home = tmp_path / "home"
+        home.mkdir()
+        (tmp_path / "homely").mkdir()
+        (tmp_path / "homely" / "note.txt").write_text("x")
+        monkeypatch.setattr(Path, "home", lambda: home)
+        monkeypatch.setattr(hal_module.Settings, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(hal_module.Settings, "DOTFILES_ROOT", tmp_path / "dotfiles")
+        monkeypatch.chdir(tmp_path)
+
+        paths = hal_instance._prepare_dotfile_entry("homely/note.txt")
+
+        assert paths.dest_path == tmp_path / "dotfiles" / "note.txt"
+        assert paths.template_dest == str(tmp_path / "homely" / "note.txt")
 
 
 class TestUnlink:
@@ -300,7 +316,7 @@ class TestUnlink:
 
         self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"})
 
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
             hal_instance.unlink(argparse.Namespace(filename=str(dest)))
 
         assert dest.is_dir()
@@ -320,7 +336,7 @@ class TestUnlink:
 
         self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/.zshrc", "dest": "{{HOME}}/.zshrc"})
 
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
             hal_instance.unlink(argparse.Namespace(filename=str(dest)))
 
         assert not dest.is_symlink()
@@ -341,7 +357,7 @@ class TestUnlink:
         entry = {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"}
         self._link_entry(hal_instance, hal_module, tmp_path, entry)
 
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
             hal_instance.unlink(argparse.Namespace(filename=str(dest)))
 
         assert sorted(p.name for p in dest.iterdir()) == ["unmanaged.md"]
@@ -359,7 +375,7 @@ class TestUnlink:
 
         self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"})
 
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
             hal_instance.unlink(argparse.Namespace(filename=str(tmp_path / "rules")))
 
         assert hal_instance.dotfiles.data["links"] == []
@@ -377,7 +393,7 @@ class TestUnlink:
         self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/sub/rules"})
 
         monkeypatch.chdir(dest.parent)
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
             hal_instance.unlink(argparse.Namespace(filename="rules"))
 
         assert hal_instance.dotfiles.data["links"] == []
@@ -394,7 +410,7 @@ class TestUnlink:
         self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"})
 
         monkeypatch.setenv("HOME", str(tmp_path))
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
             hal_instance.unlink(argparse.Namespace(filename="~/rules/"))
 
         assert hal_instance.dotfiles.data["links"] == []
@@ -411,7 +427,7 @@ class TestUnlink:
         entry = {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"}
         self._link_entry(hal_instance, hal_module, tmp_path, entry)
 
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
             hal_instance.unlink(argparse.Namespace(filename=str(tmp_path / "unmanaged")))
 
         assert "not found in manifest:" in capsys.readouterr().out
@@ -429,7 +445,7 @@ class TestMirror:
         src.write_text("content")
         dest = tmp_path / "dest.txt"
 
-        hal_module.Mirror(say=said.append).copy(str(src), str(dest))
+        hal_module.Mirror(say=said.append).copy(src, dest)
 
         assert dest.read_text() == "content"
         assert said == [f"copy {src} -> {dest}"]
@@ -443,7 +459,7 @@ class TestMirror:
         (dest / "keep.txt").write_text("k")
         (dest / "gone.txt").write_text("g")
 
-        assert hal_module.Mirror.find_orphans(str(src), str(dest)) == [dest / "gone.txt"]
+        assert hal_module.Mirror.find_orphans(src, dest) == [dest / "gone.txt"]
 
 
 class TestSyncLinks:
@@ -459,7 +475,7 @@ class TestSyncLinks:
         dest.mkdir()
         (dest / "unmanaged.md").write_text("preserve me")
 
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._sync_links({"src": str(src), "dest": str(dest)})
 
         assert not dest.is_symlink()
@@ -475,7 +491,7 @@ class TestSyncLinks:
         dest.mkdir()
         (dest / "unmanaged.md").write_text("discard me")
 
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._sync_links({"src": str(src), "dest": str(dest)}, force=True)
 
         assert dest.is_symlink()
@@ -489,7 +505,7 @@ class TestSyncLinks:
         dest = tmp_path / "dest.txt"
         dest.write_text("pre-existing")
 
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._sync_links({"src": str(src), "dest": str(dest)})
 
         assert dest.is_symlink()
@@ -506,7 +522,7 @@ class TestSyncLinks:
         dest = tmp_path / "dest"
         dest.symlink_to(stale)
 
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._sync_links({"src": str(src), "dest": str(dest)})
 
         assert dest.is_symlink()
@@ -527,7 +543,7 @@ class TestCopyEntryMerge:
         (dest / "dest_only.txt").write_text("preserve me")
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert (dest / "from_src.txt").read_text() == "source content"
@@ -544,7 +560,7 @@ class TestCopyEntryMerge:
         (dest / "shared.txt").write_text("old")
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert (dest / "shared.txt").read_text() == "updated"
@@ -560,7 +576,7 @@ class TestCopyEntryMerge:
         (dest / "existing.txt").write_text("keep")
 
         copy_entry = {"src": str(tmp_path / "src"), "dest": str(tmp_path / "dest")}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert (tmp_path / "dest" / "sub" / "new.txt").read_text() == "new"
@@ -575,7 +591,7 @@ class TestCopyEntryMerge:
         dest = tmp_path / "dest"
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert (dest / "file.txt").read_text() == "content"
@@ -589,7 +605,7 @@ class TestCopyEntryMerge:
         dest.write_text("old content")
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert dest.read_text() == "new content"
@@ -601,7 +617,7 @@ class TestCopyEntryMerge:
         dest = tmp_path / "dest" / ".DS_Store"
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert not dest.exists()
@@ -617,7 +633,7 @@ class TestCopyEntryMerge:
         dest.mkdir()
 
         copy_entry = {"src": str(src / "*"), "dest": str(dest / "*")}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert (dest / "keep.log").read_text() == "keep"
@@ -634,7 +650,7 @@ class TestCopyEntryMerge:
 
         copy_entry = {"src": str(src), "dest": str(dest)}
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_module.Settings, "IGNORE_PATTERNS", ("*.tmp",)),
         ):
             hal_instance._copy_entry(copy_entry)
@@ -652,7 +668,7 @@ class TestCopyEntryMerge:
         dest = tmp_path / "dest"
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert (dest / "real.txt").exists()
@@ -671,7 +687,7 @@ class TestCopyEntryMerge:
         dest_file.chmod(0o444)
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert dest_file.read_text() == "new content"
@@ -686,7 +702,7 @@ class TestCopyEntryMerge:
         dest.chmod(0o444)
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert dest.read_text() == "new content"
@@ -701,7 +717,7 @@ class TestCopyEntryMerge:
         dest = tmp_path / "dest"
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert (dest / "real.txt").exists()
@@ -717,7 +733,7 @@ class TestCopyEntryMerge:
         dest = tmp_path / "dest"
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert (dest / "real.txt").exists()
@@ -740,7 +756,7 @@ class TestSkipUnchanged:
         self._match_mtime(src, dest)
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert dest.read_text() == "BBBB"
@@ -754,7 +770,7 @@ class TestSkipUnchanged:
         os.utime(dest, ns=(src.stat().st_atime_ns, src.stat().st_mtime_ns + 1_000_000_000))
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert dest.read_text() == "AAAA"
@@ -768,7 +784,7 @@ class TestSkipUnchanged:
         self._match_mtime(src, dest)
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert dest.read_text() == "AAAA"
@@ -787,7 +803,7 @@ class TestSkipUnchanged:
         (dest / "changed.txt").write_text("old content")
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert (dest / "same.txt").read_text() == "BBBB"
@@ -807,7 +823,7 @@ class TestSkipUnchanged:
         dest_file.chmod(0o444)
 
         copy_entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(copy_entry)
 
         assert dest_file.read_text() == "BBBB"
@@ -828,7 +844,7 @@ class TestCopyEntryGlob:
         dest_dir = tmp_path / "dropbox"
 
         entry = {"src": str(src_dir / "*.code-workspace"), "dest": str(dest_dir / "*.code-workspace")}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(entry)
 
         assert (dest_dir / "acme.code-workspace").read_text() == "acme"
@@ -842,7 +858,7 @@ class TestCopyEntryGlob:
         dest_dir = tmp_path / "dropbox"
 
         entry = {"src": str(src_dir / "*.code-workspace"), "dest": str(dest_dir / "*.code-workspace")}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(entry)
 
         assert not dest_dir.exists()
@@ -856,7 +872,7 @@ class TestCopyEntryGlob:
         local_dir = tmp_path / "projects"
 
         swapped = {"src": str(backup_dir / "*.code-workspace"), "dest": str(local_dir / "*.code-workspace")}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(swapped)
 
         assert (local_dir / "acme.code-workspace").read_text() == "backed up"
@@ -890,7 +906,7 @@ class TestBackupRestore:
 
         entry = {"src": str(src), "dest": str(dest)}
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
         ):
             mock_dotfiles.data = {"backups": [entry]}
@@ -910,7 +926,7 @@ class TestBackupRestore:
 
         entry = {"src": str(src), "dest": str(dest)}
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
         ):
             mock_dotfiles.data = {"backups": [entry]}
@@ -929,7 +945,7 @@ class TestBackupRestore:
         entry = {"src": str(local), "dest": str(backup_file)}
         monkeypatch.setattr("builtins.input", lambda _: "y")
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
         ):
             mock_dotfiles.data = {"backups": [entry]}
@@ -947,7 +963,7 @@ class TestBackupRestore:
         entry = {"src": str(local), "dest": str(backup_file)}
         monkeypatch.setattr("builtins.input", lambda _: "y")
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
         ):
             mock_dotfiles.data = {"backups": [entry]}
@@ -965,7 +981,7 @@ class TestBackupRestore:
         entry = {"src": str(local), "dest": str(backup_file)}
         monkeypatch.setattr("builtins.input", lambda _: "")
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
         ):
             mock_dotfiles.data = {"backups": [entry]}
@@ -987,7 +1003,7 @@ class TestBackupRestore:
         entry = {"src": str(local), "dest": str(backup_file)}
         monkeypatch.setattr("builtins.input", raise_eof)
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
         ):
             mock_dotfiles.data = {"backups": [entry]}
@@ -1003,7 +1019,7 @@ class TestBackupRestore:
 
         entry = {"src": str(src), "dest": str(dest)}
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
         ):
             mock_dotfiles.data = {"links": [], "copies": [], "backups": [entry]}
@@ -1021,7 +1037,7 @@ class TestBackupRestore:
 
         with (
             patch("pathlib.Path.home", return_value=home),
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
         ):
             mock_dotfiles.data = {"backups": [{"src": str(src), "dest": str(dest)}]}
@@ -1038,7 +1054,7 @@ class TestBackupPrune:
     @staticmethod
     def _prune(hal_instance, entries, answer="y"):
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
             patch("builtins.input", return_value=answer),
         ):
@@ -1086,7 +1102,7 @@ class TestBackupPrune:
         (dest / "orphan.txt").write_text("orphan")
 
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
         ):
             mock_dotfiles.data = {"backups": [{"src": str(src), "dest": str(dest)}]}
@@ -1279,7 +1295,7 @@ class TestBackupPrune:
         (dest / "orphan.txt").write_text("orphan")
 
         entry = {"src": str(src), "dest": str(dest)}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             orphans = hal_instance._find_orphans(entry)
 
         assert orphans == [dest / "orphan.txt"]
@@ -1382,7 +1398,7 @@ class TestBackupPrune:
         dest_dir.mkdir()
 
         entry = {"src": str(src_dir / "foo-*.log"), "dest": str(dest_dir / "bar-*.log")}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(entry)
             orphans = hal_instance._find_orphans(entry)
 
@@ -1400,7 +1416,7 @@ class TestBackupPrune:
         (dest_dir / "bar-9.log").write_text("orphan")
 
         entry = {"src": str(src_dir / "foo-*.log"), "dest": str(dest_dir / "bar-*.log")}
-        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+        with patch.object(hal_instance, "_expand_template", side_effect=Path):
             hal_instance._copy_entry(entry)
             orphans = hal_instance._find_orphans(entry)
 
@@ -1418,7 +1434,7 @@ class TestBackupPrune:
             pytest.fail("prompted with nothing to prune")
 
         with (
-            patch.object(hal_instance, "_expand_template", side_effect=lambda t: t),
+            patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
             patch("builtins.input", side_effect=fail_if_called),
         ):
@@ -1503,7 +1519,7 @@ class TestPathRefusal:
         entries = {"backups": [{"src": "{{HOME}}/ok.txt", "dest": "{{HOME}}/ok.bak"}, {"src": "{{HOME}}/ok.txt", "dest": "/etc/hal-test"}], "copies": [], "links": []}
         manifest.write_text(json.dumps(entries))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setattr(hal_module.Dotfiles, "DEFAULT_CONFIG", str(manifest))
+        monkeypatch.setattr(hal_module.Dotfiles, "DEFAULT_CONFIG", manifest)
         monkeypatch.setattr(sys, "argv", ["hal", "backup"])
 
         with pytest.raises(SystemExit) as exc_info:

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -128,6 +128,15 @@ class TestValidatePath:
     def test_home_itself_is_valid(self, hal_instance):
         hal_instance._validate_path(str(Path.home()))
 
+    def test_copy_entry_rejects_an_unsafe_dest_even_when_src_is_missing(self, hal_instance, tmp_path, monkeypatch):
+        """Both paths of an entry are expanded and checked before the engine looks at either."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            hal_instance._copy_entry({"src": str(tmp_path / "missing"), "dest": "/etc/hal-test"})
+
+        assert exc_info.value.code == 1
+
 
 class TestUpdateSanitization:
     def test_extra_args_are_quoted(self, hal_instance, monkeypatch):
@@ -411,6 +420,32 @@ class TestUnlink:
         assert hal_instance.dotfiles.data["links"] == [entry]
         assert dest.is_symlink()
         assert (src / "managed.md").read_text() == "from repo"
+
+
+class TestMirror:
+    """Mirror works on expanded paths and needs only a reporter."""
+
+    def test_copy_reports_through_say(self, hal_module, tmp_path):
+        said = []
+        src = tmp_path / "src.txt"
+        src.write_text("content")
+        dest = tmp_path / "dest.txt"
+
+        hal_module.Mirror(say=said.append).copy(str(src), str(dest))
+
+        assert dest.read_text() == "content"
+        assert said == [f"copy {src} -> {dest}"]
+
+    def test_find_orphans_needs_no_reporter(self, hal_module, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "keep.txt").write_text("k")
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        (dest / "keep.txt").write_text("k")
+        (dest / "gone.txt").write_text("g")
+
+        assert hal_module.Mirror.find_orphans(str(src), str(dest)) == [dest / "gone.txt"]
 
 
 class TestSyncLinks:

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -769,6 +769,24 @@ class TestCopyEntryGlob:
         assert (local_dir / "acme.code-workspace").read_text() == "backed up"
 
 
+class TestParallel:
+    """_parallel runs every task and re-raises the first failure only after the others have finished."""
+
+    def test_failure_is_reraised_after_the_other_tasks_ran(self, hal_module):
+        finished = []
+
+        def fail():
+            raise RuntimeError
+
+        def succeed():
+            finished.append("ok")
+
+        with pytest.raises(RuntimeError):
+            hal_module.HAL9000._parallel([fail, succeed])
+
+        assert finished == ["ok"]
+
+
 class TestBackupRestore:
     """backup copies src->dest, restore copies dest->src after confirmation."""
 

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -1408,7 +1408,7 @@ class TestArgParsing:
 
 class TestManifestRoundTrip:
     def test_prune_field_survives_save(self, hal_module, tmp_path):
-        """save() rebuilds entries from ENTRY_KEY_ORDER, so an unlisted key would be dropped by any `hal link`."""
+        """prune is written back alongside src and dest."""
         manifest = tmp_path / "hal_dotfiles.json"
         entries = {"backups": [{"src": "a", "dest": "b", "prune": False}], "copies": [], "links": []}
         manifest.write_text(json.dumps(entries))
@@ -1418,3 +1418,13 @@ class TestManifestRoundTrip:
         dotfiles.save()
 
         assert json.loads(manifest.read_text())["backups"][0] == {"src": "a", "dest": "b", "prune": False}
+
+    def test_unknown_key_is_kept_after_the_known_ones(self, hal_module, tmp_path):
+        """A key the schema does not list is written back after the known keys instead of being dropped."""
+        manifest = tmp_path / "hal_dotfiles.json"
+        entries = {"backups": [{"note": "n", "dest": "b", "src": "a"}], "copies": [], "links": []}
+        manifest.write_text(json.dumps(entries))
+
+        hal_module.Dotfiles(str(manifest)).save()
+
+        assert list(json.loads(manifest.read_text())["backups"][0].items()) == [("src", "a"), ("dest", "b"), ("note", "n")]

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -20,7 +20,7 @@ class TestAbbreviateHome:
 
 class TestDotfilesLoad:
     def test_missing_manifest_loads_as_empty(self, hal_module, tmp_path):
-        dotfiles = hal_module.Dotfiles(str(tmp_path / "hal_dotfiles.json"))
+        dotfiles = hal_module.Dotfiles(tmp_path / "hal_dotfiles.json")
 
         assert dotfiles.data == {"backups": [], "copies": [], "links": []}
 
@@ -34,7 +34,7 @@ class TestDotfilesSave:
         entries = {"backups": [], "copies": [], "links": [{"src": "a", "dest": "b"}]}
         manifest.write_text(json.dumps(entries))
 
-        hal_module.Dotfiles(str(manifest)).save()
+        hal_module.Dotfiles(manifest).save()
 
         assert json.loads(manifest.read_text()) == entries
 
@@ -43,7 +43,7 @@ class TestDotfilesSave:
         entries = {"backups": [], "copies": [], "links": [{"src": "a", "dest": "b"}]}
         manifest.write_text(json.dumps(entries))
 
-        dotfiles = hal_module.Dotfiles(str(manifest))
+        dotfiles = hal_module.Dotfiles(manifest)
         assert dotfiles.data == entries
         dotfiles.save()
 
@@ -57,7 +57,7 @@ class TestDotfilesMutation:
     def _dotfiles(hal_module, tmp_path, entries):
         manifest = tmp_path / "hal_dotfiles.json"
         manifest.write_text(json.dumps(entries))
-        return hal_module.Dotfiles(str(manifest))
+        return hal_module.Dotfiles(manifest)
 
     def test_upsert_adds_a_missing_entry(self, hal_module, tmp_path):
         dotfiles = self._dotfiles(hal_module, tmp_path, {"backups": [], "copies": [], "links": []})
@@ -312,7 +312,7 @@ class TestUnlink:
     @staticmethod
     def _link_entry(hal_instance, hal_module, tmp_path, entry):
         """Point the manifest at a temp file and register one link entry as templates."""
-        hal_instance.dotfiles = hal_module.Dotfiles(str(tmp_path / "hal_dotfiles.json"))
+        hal_instance.dotfiles = hal_module.Dotfiles(tmp_path / "hal_dotfiles.json")
         hal_instance.dotfiles.data["links"].append(entry)
 
     def test_moves_directory_back_to_dest(self, hal_instance, hal_module, tmp_path):
@@ -1547,7 +1547,7 @@ class TestManifestRoundTrip:
         entries = {"backups": [{"src": "a", "dest": "b", "prune": False}], "copies": [], "links": []}
         manifest.write_text(json.dumps(entries))
 
-        dotfiles = hal_module.Dotfiles(str(manifest))
+        dotfiles = hal_module.Dotfiles(manifest)
         _ = dotfiles.data
         dotfiles.save()
 
@@ -1559,6 +1559,6 @@ class TestManifestRoundTrip:
         entries = {"backups": [{"note": "n", "dest": "b", "src": "a"}], "copies": [], "links": []}
         manifest.write_text(json.dumps(entries))
 
-        hal_module.Dotfiles(str(manifest)).save()
+        hal_module.Dotfiles(manifest).save()
 
         assert list(json.loads(manifest.read_text())["backups"][0].items()) == [("src", "a"), ("dest", "b"), ("note", "n")]

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -46,6 +46,7 @@ class TestDotfilesMutation:
         dotfiles.upsert("links", "a", "b")
 
         assert dotfiles.data["links"] == [{"src": "a", "dest": "b"}]
+        assert list(dotfiles.data["links"][0]) == ["src", "dest"]
 
     def test_upsert_repoints_an_existing_entry(self, hal_module, tmp_path):
         dotfiles = self._dotfiles(hal_module, tmp_path, {"backups": [], "links": [{"src": "a", "dest": "old"}]})
@@ -1515,27 +1516,3 @@ class TestPathRefusal:
         assert exc_info.value.code == 1
         assert (tmp_path / "ok.bak").read_text() == "ok"
         assert "I'm sorry, Dave. I'm afraid I can't do that:" in capsys.readouterr().out
-
-
-class TestManifestRoundTrip:
-    def test_prune_field_survives_save(self, hal_module, tmp_path):
-        """prune is written back alongside src and dest."""
-        manifest = tmp_path / "hal_dotfiles.json"
-        entries = {"backups": [{"src": "a", "dest": "b", "prune": False}], "links": []}
-        manifest.write_text(json.dumps(entries))
-
-        dotfiles = hal_module.Dotfiles(manifest)
-        _ = dotfiles.data
-        dotfiles.save()
-
-        assert json.loads(manifest.read_text())["backups"][0] == {"src": "a", "dest": "b", "prune": False}
-
-    def test_unknown_key_is_kept_after_the_known_ones(self, hal_module, tmp_path):
-        """A key the schema does not list is written back after the known keys instead of being dropped."""
-        manifest = tmp_path / "hal_dotfiles.json"
-        entries = {"backups": [{"note": "n", "dest": "b", "src": "a"}], "links": []}
-        manifest.write_text(json.dumps(entries))
-
-        hal_module.Dotfiles(manifest).save()
-
-        assert list(json.loads(manifest.read_text())["backups"][0].items()) == [("src", "a"), ("dest", "b"), ("note", "n")]

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -252,6 +252,27 @@ class TestUserFilenameValidation:
             hal_instance.copy(ns)
 
 
+class TestPrepareDotfileEntry:
+    def test_paths_for_a_file_under_home(self, hal_instance, hal_module, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        (home / ".config").mkdir(parents=True)
+        (home / ".config" / "app.toml").write_text("x")
+        repo = tmp_path / "repo"
+        monkeypatch.setattr(Path, "home", lambda: home)
+        monkeypatch.setattr(hal_module.Settings, "REPO_ROOT", str(repo))
+        monkeypatch.setattr(hal_module.Settings, "DOTFILES_ROOT", str(repo / "dotfiles"))
+        monkeypatch.chdir(home)
+
+        paths = hal_instance._prepare_dotfile_entry(".config/app.toml")
+
+        assert paths == hal_module.DotfilePaths(
+            filepath=str(home / ".config" / "app.toml"),
+            dest_path=str(repo / "dotfiles" / ".config" / "app.toml"),
+            template_src="{{REPO_ROOT}}/dotfiles/.config/app.toml",
+            template_dest="{{HOME}}/.config/app.toml",
+        )
+
+
 class TestUnlink:
     """unlink reverses a link entry, whether the entry names a file or a directory."""
 

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -1051,6 +1051,40 @@ class TestBackupPrune:
 
         assert (dest_dir / "only_copy.code-workspace").read_text() == "irreplaceable"
 
+    def test_glob_entry_with_renaming_pattern_keeps_what_it_just_copied(self, hal_instance, tmp_path):
+        """Copying splices the star into dest, so pruning must expect the spliced name, not the source name."""
+        src_dir = tmp_path / "projects"
+        src_dir.mkdir()
+        (src_dir / "foo-1.log").write_text("one")
+
+        dest_dir = tmp_path / "dropbox"
+        dest_dir.mkdir()
+
+        entry = {"src": str(src_dir / "foo-*.log"), "dest": str(dest_dir / "bar-*.log")}
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+            hal_instance._copy_entry(entry)
+            orphans = hal_instance._find_orphans(entry)
+
+        assert (dest_dir / "bar-1.log").read_text() == "one"
+        assert orphans == []
+
+    def test_glob_entry_with_renaming_pattern_still_reports_unmatched_files(self, hal_instance, tmp_path):
+        """A dest file whose star segment no longer has a source match is an orphan under a renaming pair."""
+        src_dir = tmp_path / "projects"
+        src_dir.mkdir()
+        (src_dir / "foo-1.log").write_text("one")
+
+        dest_dir = tmp_path / "dropbox"
+        dest_dir.mkdir()
+        (dest_dir / "bar-9.log").write_text("orphan")
+
+        entry = {"src": str(src_dir / "foo-*.log"), "dest": str(dest_dir / "bar-*.log")}
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+            hal_instance._copy_entry(entry)
+            orphans = hal_instance._find_orphans(entry)
+
+        assert orphans == [dest_dir / "bar-9.log"]
+
     def test_no_orphans_skips_the_prompt(self, hal_instance, tmp_path):
         src = tmp_path / "live"
         src.mkdir()

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -259,12 +259,12 @@ class TestUpdateWorkingDirectory:
 
 class TestUserFilenameValidation:
     def test_link_validates_filename(self, hal_instance, hal_module, tmp_path):
-        ns = argparse.Namespace(filename="../../../etc/passwd")
+        ns = argparse.Namespace(filename=Path("../../../etc/passwd"))
         with patch("pathlib.Path.cwd", return_value=tmp_path), pytest.raises(hal_module.PathNotAllowedError):
             hal_instance.link(ns)
 
     def test_copy_validates_filename(self, hal_instance, hal_module, tmp_path):
-        ns = argparse.Namespace(filename="../../../etc/passwd")
+        ns = argparse.Namespace(filename=Path("../../../etc/passwd"))
         with patch("pathlib.Path.cwd", return_value=tmp_path), pytest.raises(hal_module.PathNotAllowedError):
             hal_instance.copy(ns)
 
@@ -327,7 +327,7 @@ class TestUnlink:
         self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"})
 
         with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
-            hal_instance.unlink(argparse.Namespace(filename=str(dest)))
+            hal_instance.unlink(argparse.Namespace(filename=dest))
 
         assert dest.is_dir()
         assert not dest.is_symlink()
@@ -347,7 +347,7 @@ class TestUnlink:
         self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/.zshrc", "dest": "{{HOME}}/.zshrc"})
 
         with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
-            hal_instance.unlink(argparse.Namespace(filename=str(dest)))
+            hal_instance.unlink(argparse.Namespace(filename=dest))
 
         assert not dest.is_symlink()
         assert dest.read_text() == "from repo"
@@ -368,7 +368,7 @@ class TestUnlink:
         self._link_entry(hal_instance, hal_module, tmp_path, entry)
 
         with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
-            hal_instance.unlink(argparse.Namespace(filename=str(dest)))
+            hal_instance.unlink(argparse.Namespace(filename=dest))
 
         assert sorted(p.name for p in dest.iterdir()) == ["unmanaged.md"]
         assert (src / "managed.md").read_text() == "from repo"
@@ -386,7 +386,7 @@ class TestUnlink:
         self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"})
 
         with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
-            hal_instance.unlink(argparse.Namespace(filename=str(tmp_path / "rules")))
+            hal_instance.unlink(argparse.Namespace(filename=tmp_path / "rules"))
 
         assert hal_instance.dotfiles.data["links"] == []
 
@@ -404,7 +404,7 @@ class TestUnlink:
 
         monkeypatch.chdir(dest.parent)
         with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
-            hal_instance.unlink(argparse.Namespace(filename="rules"))
+            hal_instance.unlink(argparse.Namespace(filename=Path("rules")))
 
         assert hal_instance.dotfiles.data["links"] == []
 
@@ -421,7 +421,7 @@ class TestUnlink:
 
         monkeypatch.setenv("HOME", str(tmp_path))
         with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
-            hal_instance.unlink(argparse.Namespace(filename="~/rules/"))
+            hal_instance.unlink(argparse.Namespace(filename=Path("~/rules/")))
 
         assert hal_instance.dotfiles.data["links"] == []
 
@@ -438,7 +438,7 @@ class TestUnlink:
         self._link_entry(hal_instance, hal_module, tmp_path, entry)
 
         with patch.object(hal_instance, "_expand_template", side_effect=lambda t: Path(t.replace("{{HOME}}", str(tmp_path)))):
-            hal_instance.unlink(argparse.Namespace(filename=str(tmp_path / "unmanaged")))
+            hal_instance.unlink(argparse.Namespace(filename=tmp_path / "unmanaged"))
 
         assert "not found in manifest:" in capsys.readouterr().out
         assert hal_instance.dotfiles.data["links"] == [entry]

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -33,6 +33,38 @@ class TestDotfilesSave:
         assert json.loads(manifest.read_text()) == entries
 
 
+class TestDotfilesMutation:
+    """upsert and remove are the only writes to the manifest's entry lists."""
+
+    @staticmethod
+    def _dotfiles(hal_module, tmp_path, entries):
+        manifest = tmp_path / "hal_dotfiles.json"
+        manifest.write_text(json.dumps(entries))
+        return hal_module.Dotfiles(str(manifest))
+
+    def test_upsert_adds_a_missing_entry(self, hal_module, tmp_path):
+        dotfiles = self._dotfiles(hal_module, tmp_path, {"backups": [], "copies": [], "links": []})
+
+        dotfiles.upsert("links", "a", "b")
+
+        assert dotfiles.data["links"] == [{"src": "a", "dest": "b"}]
+
+    def test_upsert_repoints_an_existing_entry(self, hal_module, tmp_path):
+        dotfiles = self._dotfiles(hal_module, tmp_path, {"backups": [], "copies": [], "links": [{"src": "a", "dest": "old"}]})
+
+        dotfiles.upsert("links", "a", "new")
+
+        assert dotfiles.data["links"] == [{"src": "a", "dest": "new"}]
+
+    def test_remove_drops_the_entry(self, hal_module, tmp_path):
+        entries = {"backups": [], "copies": [], "links": [{"src": "a", "dest": "b"}, {"src": "c", "dest": "d"}]}
+        dotfiles = self._dotfiles(hal_module, tmp_path, entries)
+
+        dotfiles.remove("links", dotfiles.data["links"][0])
+
+        assert dotfiles.data["links"] == [{"src": "c", "dest": "d"}]
+
+
 class TestValidatePath:
     def test_valid_path_under_home(self, hal_instance):
         home = str(Path.home())

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -1412,6 +1412,24 @@ class TestArgParsing:
             hal.read_lips()
         assert exc_info.value.code == 2
 
+    def test_unknown_args_without_subcommand_rejected(self, hal_module, monkeypatch):
+        """A bare unknown flag gets the usage error, not a traceback from the missing func default."""
+        monkeypatch.setattr(sys, "argv", ["hal", "--bogus"])
+        hal = hal_module.HAL9000()
+        with pytest.raises(SystemExit) as exc_info:
+            hal.read_lips()
+        assert exc_info.value.code == 2
+
+    def test_unknown_args_pass_through_for_update(self, hal_module, monkeypatch):
+        """update forwards unrecognized arguments instead of rejecting them."""
+        forwarded = []
+        monkeypatch.setattr(hal_module.HAL9000, "update", lambda _self, _namespace, extra_args=None: forwarded.append(extra_args))
+        monkeypatch.setattr(sys, "argv", ["hal", "update", "--tags", "python"])
+
+        hal_module.HAL9000().read_lips()
+
+        assert forwarded == [["--tags", "python"]]
+
 
 class TestManifestRoundTrip:
     def test_prune_field_survives_save(self, hal_module, tmp_path):

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -95,7 +95,7 @@ class TestUpdateSanitization:
         """extra_args with shell metacharacters must be quoted."""
         commands_run = []
 
-        def mock_run(command, *, verbose=True):  # noqa: ARG001 unused-function-argument
+        def mock_run(command, *, cwd=None, verbose=True):  # noqa: ARG001 unused-function-argument
             commands_run.append(command)
             return 0
 
@@ -114,7 +114,7 @@ class TestUpdateFailurePropagation:
 
     @staticmethod
     def _install_mocks(hal_instance, monkeypatch, failing_command):
-        def mock_run(command, *, verbose=True):  # noqa: ARG001 unused-function-argument
+        def mock_run(command, *, cwd=None, verbose=True):  # noqa: ARG001 unused-function-argument
             return 1 if failing_command in command else 0
 
         monkeypatch.setattr("shutil.which", lambda _cmd: "/opt/homebrew/bin/ansible")
@@ -145,7 +145,7 @@ class TestUpdateAnsibleCheck:
     def test_non_homebrew_ansible_exits(self, hal_instance, monkeypatch):
         commands_run = []
 
-        def mock_run(command, *, verbose=True):  # noqa: ARG001 unused-function-argument
+        def mock_run(command, *, cwd=None, verbose=True):  # noqa: ARG001 unused-function-argument
             commands_run.append(command)
             return 0
 
@@ -162,7 +162,7 @@ class TestUpdateAnsibleCheck:
     def test_missing_ansible_skips_check(self, hal_instance, monkeypatch):
         commands_run = []
 
-        def mock_run(command, *, verbose=True):  # noqa: ARG001 unused-function-argument
+        def mock_run(command, *, cwd=None, verbose=True):  # noqa: ARG001 unused-function-argument
             commands_run.append(command)
             return 0
 
@@ -173,6 +173,32 @@ class TestUpdateAnsibleCheck:
         hal_instance.update(ns)
 
         assert "git fetch" in commands_run
+
+
+class TestUpdateWorkingDirectory:
+    """update runs git in the repo root and ansible-playbook in playbooks/ without changing the process's own directory."""
+
+    def test_commands_run_in_their_directories(self, hal_instance, hal_module, monkeypatch):
+        commands_run = []
+
+        def mock_run(command, *, cwd=None, verbose=True):  # noqa: ARG001 unused-function-argument
+            commands_run.append((command, cwd))
+            return 0
+
+        monkeypatch.setattr("shutil.which", lambda _cmd: "/opt/homebrew/bin/ansible")
+        hal_instance._run = mock_run
+        cwd_before = Path.cwd()
+
+        ns = argparse.Namespace(func=hal_instance.update)
+        hal_instance.update(ns)
+
+        repo_root = hal_module.Settings.REPO_ROOT
+        assert commands_run == [
+            ("git fetch", repo_root),
+            ("git pull", repo_root),
+            ("ansible-playbook site.yml -v", str(Path(repo_root) / "playbooks")),
+        ]
+        assert Path.cwd() == cwd_before
 
 
 class TestUserFilenameValidation:

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -18,27 +18,8 @@ class TestAbbreviateHome:
         assert hal_module.abbreviate_home(tmp_path / "homely" / "x") == str(tmp_path / "homely" / "x")
 
 
-class TestDotfilesLoad:
-    def test_missing_manifest_loads_as_empty(self, hal_module, tmp_path):
-        dotfiles = hal_module.Dotfiles(tmp_path / "hal_dotfiles.json")
-
-        assert dotfiles.data == {"backups": [], "links": []}
-
-
 class TestDotfilesSave:
-    """save() truncates the manifest, so it must build its payload first."""
-
-    def test_save_before_any_read_preserves_manifest(self, hal_module, tmp_path):
-        """Manifest data loads lazily, so saving an untouched Dotfiles must not lose it."""
-        manifest = tmp_path / "hal_dotfiles.json"
-        entries = {"backups": [], "links": [{"src": "a", "dest": "b"}]}
-        manifest.write_text(json.dumps(entries))
-
-        hal_module.Dotfiles(manifest).save()
-
-        assert json.loads(manifest.read_text()) == entries
-
-    def test_save_after_read_preserves_manifest(self, hal_module, tmp_path):
+    def test_save_preserves_manifest(self, hal_module, tmp_path):
         manifest = tmp_path / "hal_dotfiles.json"
         entries = {"backups": [], "links": [{"src": "a", "dest": "b"}]}
         manifest.write_text(json.dumps(entries))
@@ -310,8 +291,9 @@ class TestUnlink:
     @staticmethod
     def _link_entry(hal_instance, hal_module, tmp_path, entry):
         """Point the manifest at a temp file and register one link entry as templates."""
-        hal_instance.dotfiles = hal_module.Dotfiles(tmp_path / "hal_dotfiles.json")
-        hal_instance.dotfiles.data["links"].append(entry)
+        manifest = tmp_path / "hal_dotfiles.json"
+        manifest.write_text(json.dumps({"backups": [], "links": [entry]}))
+        hal_instance.dotfiles = hal_module.Dotfiles(manifest)
 
     def test_moves_directory_back_to_dest(self, hal_instance, hal_module, tmp_path):
         """A directory entry is restored whole, which shutil.copy2 could never do."""

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -179,7 +179,7 @@ class TestUnlink:
         self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"})
 
         with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
-            hal_instance.unlink(argparse.Namespace(filename="~/rules/"))
+            hal_instance.unlink(argparse.Namespace(filename=str(dest)))
 
         assert dest.is_dir()
         assert not dest.is_symlink()
@@ -199,7 +199,7 @@ class TestUnlink:
         self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/.zshrc", "dest": "{{HOME}}/.zshrc"})
 
         with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
-            hal_instance.unlink(argparse.Namespace(filename="~/.zshrc"))
+            hal_instance.unlink(argparse.Namespace(filename=str(dest)))
 
         assert not dest.is_symlink()
         assert dest.read_text() == "from repo"
@@ -220,11 +220,82 @@ class TestUnlink:
         self._link_entry(hal_instance, hal_module, tmp_path, entry)
 
         with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
-            hal_instance.unlink(argparse.Namespace(filename="~/rules/"))
+            hal_instance.unlink(argparse.Namespace(filename=str(dest)))
 
         assert sorted(p.name for p in dest.iterdir()) == ["unmanaged.md"]
         assert (src / "managed.md").read_text() == "from repo"
         assert hal_instance.dotfiles.data["links"] == [entry]
+
+    def test_matches_entry_dest_with_trailing_slash(self, hal_instance, hal_module, tmp_path):
+        """Directory entries are hand-written with a trailing slash the typed path never has."""
+        src = tmp_path / "dotfiles" / "rules"
+        src.mkdir(parents=True)
+        (src / "managed.md").write_text("from repo")
+
+        dest = tmp_path / "rules"
+        dest.symlink_to(src)
+
+        self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"})
+
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+            hal_instance.unlink(argparse.Namespace(filename=str(tmp_path / "rules")))
+
+        assert hal_instance.dotfiles.data["links"] == []
+
+    def test_matches_entry_from_relative_filename(self, hal_instance, hal_module, tmp_path, monkeypatch):
+        """A bare name is resolved against the current directory, not against the home directory."""
+        src = tmp_path / "dotfiles" / "rules"
+        src.mkdir(parents=True)
+        (src / "managed.md").write_text("from repo")
+
+        dest = tmp_path / "sub" / "rules"
+        dest.parent.mkdir()
+        dest.symlink_to(src)
+
+        self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/sub/rules"})
+
+        monkeypatch.chdir(dest.parent)
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+            hal_instance.unlink(argparse.Namespace(filename="rules"))
+
+        assert hal_instance.dotfiles.data["links"] == []
+
+    def test_matches_entry_from_tilde_filename(self, hal_instance, hal_module, tmp_path, monkeypatch):
+        """A quoted ~/ reaches hal unexpanded, since the shell never saw it."""
+        src = tmp_path / "dotfiles" / "rules"
+        src.mkdir(parents=True)
+        (src / "managed.md").write_text("from repo")
+
+        dest = tmp_path / "rules"
+        dest.symlink_to(src)
+
+        self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"})
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+            hal_instance.unlink(argparse.Namespace(filename="~/rules/"))
+
+        assert hal_instance.dotfiles.data["links"] == []
+
+    def test_reports_path_no_entry_covers(self, hal_instance, hal_module, tmp_path, capsys):
+        """A path outside the manifest leaves both the manifest and the filesystem alone."""
+        src = tmp_path / "dotfiles" / "rules"
+        src.mkdir(parents=True)
+        (src / "managed.md").write_text("from repo")
+
+        dest = tmp_path / "rules"
+        dest.symlink_to(src)
+
+        entry = {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"}
+        self._link_entry(hal_instance, hal_module, tmp_path, entry)
+
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+            hal_instance.unlink(argparse.Namespace(filename=str(tmp_path / "unmanaged")))
+
+        assert "not found in manifest:" in capsys.readouterr().out
+        assert hal_instance.dotfiles.data["links"] == [entry]
+        assert dest.is_symlink()
+        assert (src / "managed.md").read_text() == "from repo"
 
 
 class TestSyncLinks:

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -22,7 +22,7 @@ class TestDotfilesLoad:
     def test_missing_manifest_loads_as_empty(self, hal_module, tmp_path):
         dotfiles = hal_module.Dotfiles(tmp_path / "hal_dotfiles.json")
 
-        assert dotfiles.data == {"backups": [], "copies": [], "links": []}
+        assert dotfiles.data == {"backups": [], "links": []}
 
 
 class TestDotfilesSave:
@@ -31,7 +31,7 @@ class TestDotfilesSave:
     def test_save_before_any_read_preserves_manifest(self, hal_module, tmp_path):
         """Manifest data loads lazily, so saving an untouched Dotfiles must not lose it."""
         manifest = tmp_path / "hal_dotfiles.json"
-        entries = {"backups": [], "copies": [], "links": [{"src": "a", "dest": "b"}]}
+        entries = {"backups": [], "links": [{"src": "a", "dest": "b"}]}
         manifest.write_text(json.dumps(entries))
 
         hal_module.Dotfiles(manifest).save()
@@ -40,7 +40,7 @@ class TestDotfilesSave:
 
     def test_save_after_read_preserves_manifest(self, hal_module, tmp_path):
         manifest = tmp_path / "hal_dotfiles.json"
-        entries = {"backups": [], "copies": [], "links": [{"src": "a", "dest": "b"}]}
+        entries = {"backups": [], "links": [{"src": "a", "dest": "b"}]}
         manifest.write_text(json.dumps(entries))
 
         dotfiles = hal_module.Dotfiles(manifest)
@@ -60,21 +60,21 @@ class TestDotfilesMutation:
         return hal_module.Dotfiles(manifest)
 
     def test_upsert_adds_a_missing_entry(self, hal_module, tmp_path):
-        dotfiles = self._dotfiles(hal_module, tmp_path, {"backups": [], "copies": [], "links": []})
+        dotfiles = self._dotfiles(hal_module, tmp_path, {"backups": [], "links": []})
 
         dotfiles.upsert("links", "a", "b")
 
         assert dotfiles.data["links"] == [{"src": "a", "dest": "b"}]
 
     def test_upsert_repoints_an_existing_entry(self, hal_module, tmp_path):
-        dotfiles = self._dotfiles(hal_module, tmp_path, {"backups": [], "copies": [], "links": [{"src": "a", "dest": "old"}]})
+        dotfiles = self._dotfiles(hal_module, tmp_path, {"backups": [], "links": [{"src": "a", "dest": "old"}]})
 
         dotfiles.upsert("links", "a", "new")
 
         assert dotfiles.data["links"] == [{"src": "a", "dest": "new"}]
 
     def test_remove_drops_the_entry(self, hal_module, tmp_path):
-        entries = {"backups": [], "copies": [], "links": [{"src": "a", "dest": "b"}, {"src": "c", "dest": "d"}]}
+        entries = {"backups": [], "links": [{"src": "a", "dest": "b"}, {"src": "c", "dest": "d"}]}
         dotfiles = self._dotfiles(hal_module, tmp_path, entries)
 
         dotfiles.remove("links", dotfiles.data["links"][0])
@@ -261,11 +261,6 @@ class TestUserFilenameValidation:
         ns = argparse.Namespace(filename=Path("../../../etc/passwd"))
         with patch("pathlib.Path.cwd", return_value=tmp_path), pytest.raises(hal_module.PathNotAllowedError):
             hal_instance.link(ns)
-
-    def test_copy_validates_filename(self, hal_instance, hal_module, tmp_path):
-        ns = argparse.Namespace(filename=Path("../../../etc/passwd"))
-        with patch("pathlib.Path.cwd", return_value=tmp_path), pytest.raises(hal_module.PathNotAllowedError):
-            hal_instance.copy(ns)
 
 
 class TestPrepareDotfileEntry:
@@ -1018,7 +1013,7 @@ class TestBackupRestore:
         assert local.read_text() == "untouched"
 
     def test_sync_ignores_backups(self, hal_instance, tmp_path):
-        """sync only processes links and copies, never backup entries."""
+        """sync only processes links, never backup entries."""
         src = tmp_path / "live.txt"
         src.write_text("live data")
         dest = tmp_path / "dropbox" / "live.txt"
@@ -1028,7 +1023,7 @@ class TestBackupRestore:
             patch.object(hal_instance, "_expand_template", side_effect=Path),
             patch.object(hal_instance, "dotfiles") as mock_dotfiles,
         ):
-            mock_dotfiles.data = {"links": [], "copies": [], "backups": [entry]}
+            mock_dotfiles.data = {"links": [], "backups": [entry]}
             hal_instance.sync(argparse.Namespace())
 
         assert not dest.exists()
@@ -1522,7 +1517,7 @@ class TestPathRefusal:
     def test_unsafe_manifest_entry_exits_1_after_the_other_entries_finish(self, hal_module, tmp_path, monkeypatch, capsys):
         (tmp_path / "ok.txt").write_text("ok")
         manifest = tmp_path / "hal_dotfiles.json"
-        entries = {"backups": [{"src": "{{HOME}}/ok.txt", "dest": "{{HOME}}/ok.bak"}, {"src": "{{HOME}}/ok.txt", "dest": "/etc/hal-test"}], "copies": [], "links": []}
+        entries = {"backups": [{"src": "{{HOME}}/ok.txt", "dest": "{{HOME}}/ok.bak"}, {"src": "{{HOME}}/ok.txt", "dest": "/etc/hal-test"}], "links": []}
         manifest.write_text(json.dumps(entries))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setattr(hal_module.Dotfiles, "DEFAULT_CONFIG", manifest)
@@ -1540,7 +1535,7 @@ class TestManifestRoundTrip:
     def test_prune_field_survives_save(self, hal_module, tmp_path):
         """prune is written back alongside src and dest."""
         manifest = tmp_path / "hal_dotfiles.json"
-        entries = {"backups": [{"src": "a", "dest": "b", "prune": False}], "copies": [], "links": []}
+        entries = {"backups": [{"src": "a", "dest": "b", "prune": False}], "links": []}
         manifest.write_text(json.dumps(entries))
 
         dotfiles = hal_module.Dotfiles(manifest)
@@ -1552,7 +1547,7 @@ class TestManifestRoundTrip:
     def test_unknown_key_is_kept_after_the_known_ones(self, hal_module, tmp_path):
         """A key the schema does not list is written back after the known keys instead of being dropped."""
         manifest = tmp_path / "hal_dotfiles.json"
-        entries = {"backups": [{"note": "n", "dest": "b", "src": "a"}], "copies": [], "links": []}
+        entries = {"backups": [{"note": "n", "dest": "b", "src": "a"}], "links": []}
         manifest.write_text(json.dumps(entries))
 
         hal_module.Dotfiles(manifest).save()

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -263,8 +263,13 @@ class TestUserFilenameValidation:
             hal_instance.link(ns)
 
 
-class TestPrepareDotfileEntry:
-    def test_paths_for_a_file_under_home(self, hal_instance, hal_module, tmp_path, monkeypatch):
+class TestLink:
+    @staticmethod
+    def _manifest(hal_instance, hal_module, path):
+        path.write_text(json.dumps({"backups": [], "links": []}))
+        hal_instance.dotfiles = hal_module.Dotfiles(path)
+
+    def test_moves_a_file_under_home_into_dotfiles_and_links_it_back(self, hal_instance, hal_module, tmp_path, monkeypatch):
         home = tmp_path / "home"
         (home / ".config").mkdir(parents=True)
         (home / ".config" / "app.toml").write_text("x")
@@ -273,15 +278,13 @@ class TestPrepareDotfileEntry:
         monkeypatch.setattr(hal_module.Settings, "REPO_ROOT", repo)
         monkeypatch.setattr(hal_module.Settings, "DOTFILES_ROOT", repo / "dotfiles")
         monkeypatch.chdir(home)
+        self._manifest(hal_instance, hal_module, tmp_path / "hal_dotfiles.json")
 
-        paths = hal_instance._prepare_dotfile_entry(".config/app.toml")
+        hal_instance.link(argparse.Namespace(filename=Path(".config/app.toml")))
 
-        assert paths == hal_module.DotfilePaths(
-            filepath=home / ".config" / "app.toml",
-            dest_path=repo / "dotfiles" / ".config" / "app.toml",
-            template_src="{{REPO_ROOT}}/dotfiles/.config/app.toml",
-            template_dest="{{HOME}}/.config/app.toml",
-        )
+        assert (repo / "dotfiles" / ".config" / "app.toml").read_text() == "x"
+        assert (home / ".config" / "app.toml").readlink() == repo / "dotfiles" / ".config" / "app.toml"
+        assert hal_instance.dotfiles.data["links"] == [{"src": "{{REPO_ROOT}}/dotfiles/.config/app.toml", "dest": "{{HOME}}/.config/app.toml"}]
 
     def test_sibling_of_home_is_not_treated_as_inside_it(self, hal_instance, hal_module, tmp_path, monkeypatch):
         """A path that merely shares home's prefix is outside it, so it lands under dotfiles/ by bare name."""
@@ -293,11 +296,12 @@ class TestPrepareDotfileEntry:
         monkeypatch.setattr(hal_module.Settings, "REPO_ROOT", tmp_path)
         monkeypatch.setattr(hal_module.Settings, "DOTFILES_ROOT", tmp_path / "dotfiles")
         monkeypatch.chdir(tmp_path)
+        self._manifest(hal_instance, hal_module, tmp_path / "hal_dotfiles.json")
 
-        paths = hal_instance._prepare_dotfile_entry("homely/note.txt")
+        hal_instance.link(argparse.Namespace(filename=Path("homely/note.txt")))
 
-        assert paths.dest_path == tmp_path / "dotfiles" / "note.txt"
-        assert paths.template_dest == str(tmp_path / "homely" / "note.txt")
+        assert (tmp_path / "dotfiles" / "note.txt").read_text() == "x"
+        assert hal_instance.dotfiles.data["links"] == [{"src": "{{REPO_ROOT}}/dotfiles/note.txt", "dest": str(tmp_path / "homely" / "note.txt")}]
 
 
 class TestUnlink:

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -141,8 +141,8 @@ class TestUpdateSanitization:
         monkeypatch.setattr("shutil.which", lambda _cmd: "/opt/homebrew/bin/ansible")
         hal_instance._run = mock_run
 
-        ns = argparse.Namespace(func=hal_instance.update)
-        hal_instance.update(ns, extra_args=["--tags", "foo;rm -rf ~"])
+        ns = argparse.Namespace(func=hal_instance.update, extra_args=["--tags", "foo;rm -rf ~"])
+        hal_instance.update(ns)
 
         ansible_cmd = next(c for c in commands_run if "ansible-playbook" in c)
         assert "'foo;rm -rf ~'" in ansible_cmd
@@ -162,7 +162,7 @@ class TestUpdateFailurePropagation:
     def test_git_pull_failure_exits(self, hal_instance, monkeypatch):
         self._install_mocks(hal_instance, monkeypatch, "git pull")
 
-        ns = argparse.Namespace(func=hal_instance.update)
+        ns = argparse.Namespace(func=hal_instance.update, extra_args=[])
         with pytest.raises(SystemExit) as excinfo:
             hal_instance.update(ns)
 
@@ -171,7 +171,7 @@ class TestUpdateFailurePropagation:
     def test_playbook_failure_exits(self, hal_instance, monkeypatch):
         self._install_mocks(hal_instance, monkeypatch, "ansible-playbook")
 
-        ns = argparse.Namespace(func=hal_instance.update)
+        ns = argparse.Namespace(func=hal_instance.update, extra_args=[])
         with pytest.raises(SystemExit) as excinfo:
             hal_instance.update(ns)
 
@@ -191,7 +191,7 @@ class TestUpdateAnsibleCheck:
         monkeypatch.setattr("shutil.which", lambda _cmd: "/usr/local/bin/ansible")
         hal_instance._run = mock_run
 
-        ns = argparse.Namespace(func=hal_instance.update)
+        ns = argparse.Namespace(func=hal_instance.update, extra_args=[])
         with pytest.raises(SystemExit) as excinfo:
             hal_instance.update(ns)
 
@@ -208,7 +208,7 @@ class TestUpdateAnsibleCheck:
         monkeypatch.setattr("shutil.which", lambda _cmd: None)
         hal_instance._run = mock_run
 
-        ns = argparse.Namespace(func=hal_instance.update)
+        ns = argparse.Namespace(func=hal_instance.update, extra_args=[])
         hal_instance.update(ns)
 
         assert "git fetch" in commands_run
@@ -228,7 +228,7 @@ class TestUpdateWorkingDirectory:
         hal_instance._run = mock_run
         cwd_before = Path.cwd()
 
-        ns = argparse.Namespace(func=hal_instance.update)
+        ns = argparse.Namespace(func=hal_instance.update, extra_args=[])
         hal_instance.update(ns)
 
         repo_root = hal_module.Settings.REPO_ROOT
@@ -1423,7 +1423,7 @@ class TestArgParsing:
     def test_unknown_args_pass_through_for_update(self, hal_module, monkeypatch):
         """update forwards unrecognized arguments instead of rejecting them."""
         forwarded = []
-        monkeypatch.setattr(hal_module.HAL9000, "update", lambda _self, _namespace, extra_args=None: forwarded.append(extra_args))
+        monkeypatch.setattr(hal_module.HAL9000, "update", lambda _self, namespace: forwarded.append(namespace.extra_args))
         monkeypatch.setattr(sys, "argv", ["hal", "update", "--tags", "python"])
 
         hal_module.HAL9000().read_lips()

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -528,6 +528,21 @@ class TestCopyEntryMerge:
 
         assert dest_file.read_text() == "new content"
 
+    def test_overwrites_readonly_single_file(self, hal_instance, tmp_path):
+        """A single-file copy overwrites a read-only dest file, like the directory branch does."""
+        src = tmp_path / "src.txt"
+        src.write_text("new content")
+
+        dest = tmp_path / "dest.txt"
+        dest.write_text("old")
+        dest.chmod(0o444)
+
+        copy_entry = {"src": str(src), "dest": str(dest)}
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t):
+            hal_instance._copy_entry(copy_entry)
+
+        assert dest.read_text() == "new content"
+
     def test_skips_pycache_directory(self, hal_instance, tmp_path):
         """__pycache__ directories in src are not copied to dest."""
         src = tmp_path / "src"

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -8,6 +8,13 @@ from unittest.mock import patch
 import pytest
 
 
+class TestDotfilesLoad:
+    def test_missing_manifest_loads_as_empty(self, hal_module, tmp_path):
+        dotfiles = hal_module.Dotfiles(str(tmp_path / "hal_dotfiles.json"))
+
+        assert dotfiles.data == {"backups": [], "copies": [], "links": []}
+
+
 class TestDotfilesSave:
     """save() truncates the manifest, so it must build its payload first."""
 

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -158,6 +158,75 @@ class TestUserFilenameValidation:
             hal_instance.copy(ns)
 
 
+class TestUnlink:
+    """unlink reverses a link entry, whether the entry names a file or a directory."""
+
+    @staticmethod
+    def _link_entry(hal_instance, hal_module, tmp_path, entry):
+        """Point the manifest at a temp file and register one link entry as templates."""
+        hal_instance.dotfiles = hal_module.Dotfiles(str(tmp_path / "hal_dotfiles.json"))
+        hal_instance.dotfiles.data["links"].append(entry)
+
+    def test_moves_directory_back_to_dest(self, hal_instance, hal_module, tmp_path):
+        """A directory entry is restored whole, which shutil.copy2 could never do."""
+        src = tmp_path / "dotfiles" / "rules"
+        src.mkdir(parents=True)
+        (src / "managed.md").write_text("from repo")
+
+        dest = tmp_path / "rules"
+        dest.symlink_to(src)
+
+        self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"})
+
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+            hal_instance.unlink(argparse.Namespace(filename="~/rules/"))
+
+        assert dest.is_dir()
+        assert not dest.is_symlink()
+        assert (dest / "managed.md").read_text() == "from repo"
+        assert not src.exists()
+        assert hal_instance.dotfiles.data["links"] == []
+
+    def test_moves_file_back_to_dest(self, hal_instance, hal_module, tmp_path):
+        """The single-file case the old copy2 handled keeps working under shutil.move."""
+        src = tmp_path / "dotfiles" / ".zshrc"
+        src.parent.mkdir(parents=True)
+        src.write_text("from repo")
+
+        dest = tmp_path / ".zshrc"
+        dest.symlink_to(src)
+
+        self._link_entry(hal_instance, hal_module, tmp_path, {"src": "{{HOME}}/dotfiles/.zshrc", "dest": "{{HOME}}/.zshrc"})
+
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+            hal_instance.unlink(argparse.Namespace(filename="~/.zshrc"))
+
+        assert not dest.is_symlink()
+        assert dest.read_text() == "from repo"
+        assert not src.exists()
+        assert hal_instance.dotfiles.data["links"] == []
+
+    def test_refuses_to_replace_real_directory(self, hal_instance, hal_module, tmp_path):
+        """A real directory at dest is what sync refused to link, so unlink leaves it alone."""
+        src = tmp_path / "dotfiles" / "rules"
+        src.mkdir(parents=True)
+        (src / "managed.md").write_text("from repo")
+
+        dest = tmp_path / "rules"
+        dest.mkdir()
+        (dest / "unmanaged.md").write_text("preserve me")
+
+        entry = {"src": "{{HOME}}/dotfiles/rules/", "dest": "{{HOME}}/rules/"}
+        self._link_entry(hal_instance, hal_module, tmp_path, entry)
+
+        with patch.object(hal_instance, "_expand_template", side_effect=lambda t: t.replace("{{HOME}}", str(tmp_path))):
+            hal_instance.unlink(argparse.Namespace(filename="~/rules/"))
+
+        assert sorted(p.name for p in dest.iterdir()) == ["unmanaged.md"]
+        assert (src / "managed.md").read_text() == "from repo"
+        assert hal_instance.dotfiles.data["links"] == [entry]
+
+
 class TestSyncLinks:
     """_sync_links never destroys a real directory unless forced."""
 

--- a/tests/bin/test_hal.py
+++ b/tests/bin/test_hal.py
@@ -82,18 +82,18 @@ class TestValidatePath:
         path = f"{hal_module.Settings.REPO_ROOT}/dotfiles/.zshrc"
         hal_instance._validate_path(path)
 
-    def test_path_traversal_outside_home(self, hal_instance):
+    def test_path_traversal_outside_home(self, hal_instance, hal_module):
         home = str(Path.home())
         path = f"{home}/../../etc/passwd"
-        with pytest.raises(SystemExit):
+        with pytest.raises(hal_module.PathNotAllowedError):
             hal_instance._validate_path(path)
 
-    def test_path_to_etc(self, hal_instance):
-        with pytest.raises(SystemExit):
+    def test_path_to_etc(self, hal_instance, hal_module):
+        with pytest.raises(hal_module.PathNotAllowedError):
             hal_instance._validate_path("/etc/crontab")
 
-    def test_path_traversal_in_template_expansion(self, hal_instance):
-        with pytest.raises(SystemExit):
+    def test_path_traversal_in_template_expansion(self, hal_instance, hal_module):
+        with pytest.raises(hal_module.PathNotAllowedError):
             hal_instance._expand_template("{{HOME}}/../../etc/crontab")
 
     def test_normal_template_expansion(self, hal_instance):
@@ -112,7 +112,7 @@ class TestValidatePath:
             patch.object(hal_module.Settings, "REPO_ROOT", str((tmp_path / "repo").resolve())),
         ):
             hal_instance._validate_path(f"{home}/inside/stuff")
-            with pytest.raises(SystemExit):
+            with pytest.raises(hal_module.PathNotAllowedError):
                 hal_instance._validate_path(f"{home}-elsewhere/stuff")
 
     def test_sibling_directory_sharing_repo_root_prefix(self, hal_instance, hal_module, tmp_path):
@@ -122,20 +122,18 @@ class TestValidatePath:
             patch.object(hal_module.Settings, "REPO_ROOT", str(repo_root)),
         ):
             hal_instance._validate_path(f"{repo_root}/inside/stuff")
-            with pytest.raises(SystemExit):
+            with pytest.raises(hal_module.PathNotAllowedError):
                 hal_instance._validate_path(f"{repo_root}-elsewhere/stuff")
 
     def test_home_itself_is_valid(self, hal_instance):
         hal_instance._validate_path(str(Path.home()))
 
-    def test_copy_entry_rejects_an_unsafe_dest_even_when_src_is_missing(self, hal_instance, tmp_path, monkeypatch):
+    def test_copy_entry_rejects_an_unsafe_dest_even_when_src_is_missing(self, hal_instance, hal_module, tmp_path, monkeypatch):
         """Both paths of an entry are expanded and checked before the engine looks at either."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(hal_module.PathNotAllowedError):
             hal_instance._copy_entry({"src": str(tmp_path / "missing"), "dest": "/etc/hal-test"})
-
-        assert exc_info.value.code == 1
 
 
 class TestUpdateSanitization:
@@ -250,14 +248,14 @@ class TestUpdateWorkingDirectory:
 
 
 class TestUserFilenameValidation:
-    def test_link_validates_filename(self, hal_instance, tmp_path):
+    def test_link_validates_filename(self, hal_instance, hal_module, tmp_path):
         ns = argparse.Namespace(filename="../../../etc/passwd")
-        with patch("pathlib.Path.cwd", return_value=tmp_path), pytest.raises(SystemExit):
+        with patch("pathlib.Path.cwd", return_value=tmp_path), pytest.raises(hal_module.PathNotAllowedError):
             hal_instance.link(ns)
 
-    def test_copy_validates_filename(self, hal_instance, tmp_path):
+    def test_copy_validates_filename(self, hal_instance, hal_module, tmp_path):
         ns = argparse.Namespace(filename="../../../etc/passwd")
-        with patch("pathlib.Path.cwd", return_value=tmp_path), pytest.raises(SystemExit):
+        with patch("pathlib.Path.cwd", return_value=tmp_path), pytest.raises(hal_module.PathNotAllowedError):
             hal_instance.copy(ns)
 
 
@@ -1485,6 +1483,35 @@ class TestArgParsing:
         hal_module.HAL9000().read_lips()
 
         assert forwarded == [["--tags", "python"]]
+
+
+class TestPathRefusal:
+    """PathNotAllowedError raised anywhere below dispatch becomes the refusal line and exit code 1."""
+
+    def test_unsafe_filename_exits_1_with_the_refusal(self, hal_module, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["hal", "link", "/etc/passwd"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            hal_module.HAL9000().read_lips()
+
+        assert exc_info.value.code == 1
+        assert "I'm sorry, Dave. I'm afraid I can't do that:" in capsys.readouterr().out
+
+    def test_unsafe_manifest_entry_exits_1_after_the_other_entries_finish(self, hal_module, tmp_path, monkeypatch, capsys):
+        (tmp_path / "ok.txt").write_text("ok")
+        manifest = tmp_path / "hal_dotfiles.json"
+        entries = {"backups": [{"src": "{{HOME}}/ok.txt", "dest": "{{HOME}}/ok.bak"}, {"src": "{{HOME}}/ok.txt", "dest": "/etc/hal-test"}], "copies": [], "links": []}
+        manifest.write_text(json.dumps(entries))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(hal_module.Dotfiles, "DEFAULT_CONFIG", str(manifest))
+        monkeypatch.setattr(sys, "argv", ["hal", "backup"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            hal_module.HAL9000().read_lips()
+
+        assert exc_info.value.code == 1
+        assert (tmp_path / "ok.bak").read_text() == "ok"
+        assert "I'm sorry, Dave. I'm afraid I can't do that:" in capsys.readouterr().out
 
 
 class TestManifestRoundTrip:

--- a/uv.lock
+++ b/uv.lock
@@ -66,15 +66,6 @@ wheels = [
 ]
 
 [[package]]
-name = "argcomplete"
-version = "3.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/c0/c8e94135e66fabf89a120d9b4b123fe6993506beca6c1938a74c24cfa5fd/argcomplete-3.7.0.tar.gz", hash = "sha256:afde224f753f874807b1dc1414e883ab8fe0cda9c04807b6047dcb8e1ac23913", size = 73284, upload-time = "2026-06-30T22:28:22.249Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/f6/5b8ec087cd9cfa9449491ec83f76fb6b7006b4dff57d2ba8aaab330fe8e4/argcomplete-3.7.0-py3-none-any.whl", hash = "sha256:d8f0f22d2a8a7caa383be1e22b6caf1ecaf0ebd10d8f83cc125e36540c95830c", size = 42575, upload-time = "2026-06-30T22:28:20.547Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -291,7 +282,6 @@ audit = [
 ]
 dev = [
     { name = "ansible-lint" },
-    { name = "argcomplete" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
@@ -314,7 +304,6 @@ test = [
 audit = [{ name = "pre-commit", specifier = ">=4.6.1" }]
 dev = [
     { name = "ansible-lint", specifier = ">=26.6.0" },
-    { name = "argcomplete", specifier = ">=3.7.0" },
     { name = "pre-commit", specifier = ">=4.6.1" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.16.0" },


### PR DESCRIPTION
Cleanup pass over `bin/hal.py`. The refactors surfaced 8 real bugs, so the fixes ride along in the same branch.

## Fixes

- `hal backup --prune` could delete the backup it just wrote. `_copy_entry` and `_find_orphans` each expanded `*` entries on their own and disagreed, so with a pair like `foo-*.log` -> `bar-*.log` every freshly copied file read as an orphan. Latent in the real manifest because its one glob entry uses the same pattern on both sides.
- `hal unlink` crashed on a directory entry, leaving nothing at dest while the manifest still listed it. It uses `shutil.move` instead of copy-then-delete now, and refuses when dest is a real directory.
- `hal unlink ~/.zshrc` matched nothing. The shell expands `~` before hal runs, so the `{{HOME}}/` lookup key it built never matched an entry. The lookup compares absolute paths now.
- `hal link` on a path that was already a symlink into `dotfiles/` destroyed the dotfile. `_prepare_dotfile_entry` calls `resolve()`, which follows the symlink into the repo, so `filepath` and `dest_path` end up equal. `shutil.move` then does nothing, and the unlink branch before `symlink_to` deleted the real file. That branch is gone, so the case now raises `FileExistsError` and the file survives.
- Copying onto a read-only file raised `PermissionError`. The single-file branch called `shutil.copy2` bare and skipped the helper that adds `S_IWUSR`, which the directory branch already used.
- Saving `hal_dotfiles.json` silently dropped any entry key outside `src`, `dest`, and `prune`.
- `_validate_path` called `sys.exit(1)` from inside worker threads, which only worked because `SystemExit` rode back on the future. It raises `PathNotAllowedError` now, and `read_lips` prints the same refusal and exits 1.
- `hal --bogus` with no subcommand crashed with `AttributeError`. Now it is an argparse usage error, exit 2.

## Refactors

- The copy/link/orphan engine is a `Mirror` class now. `HAL9000` keeps the CLI, the manifest, path templating, and three adapters that turn a manifest entry into expanded paths.
- Manifest loading and writes live in `Dotfiles`: it reads the file in `__init__`, and `upsert` and `remove` are the only writes. `_prepare_dotfile_entry` is inlined into `link()`, its only caller once `hal copy` was gone.
- `backup` and `restore` share one thread-pool helper, `_copy_entries(entries)`. Links run serially in manifest order, since a benchmark measured 1.68ms median serial against 1.65ms parallel over 20 links, with parallel's max worse at 2.56ms from thread spin-up. Serial output is stable instead of racy.
- Filesystem paths are `Path` everywhere, so `_expand_template` is the only boundary between manifest text and the filesystem.
- `shutil.which` replaces `_run_with_output`, per-call `cwd` replaces `os.chdir`, `extra_args` goes through the namespace, and a `passthrough` flag replaces the `namespace.func != self.update` identity check.
- Docstrings that only restated the code are gone. The ones carrying a reason became comments at the line they explain.

## Deletions

- The `git fetch` before `git pull` in `update()`. `git pull` runs `git fetch` with the same arguments, and a scratch-repo test confirmed a bare `git pull` updates every remote-tracking ref, not just the current branch's upstream. The fetch's return code was discarded anyway.
- The `hal copy` command and the whole `copies` manifest field. The manifest carried `"copies": []` and nothing ever populated it. A copy has no advantage over a link here: a link keeps `dotfiles/` the single source of truth, while a copy diverges the moment either side is edited. `Mirror.copy` and `_copy_entry` stay, since backup and restore still use them.
- The `dest_path.parent != Settings.DOTFILES_ROOT` guard around a `mkdir(parents=True, exist_ok=True)` that already handles that case.
- The duplicated input/EOFError/"y"/"aborted" block in `_prune` and `restore`, now one `_confirm()` helper.
- argcomplete. No shell registers it, and the `python3` the shebang resolves to lacks the module, so every run set it to `None`. Zsh completion is the generated `.hal_completion.zsh`, and its generator output is byte-identical with the import blocked. The dev dependency and the Context7 rows go with it.
- The lazy `data` property and its missing-file fallback. Reading the manifest in `__init__` removes the `save()` truncation hazard, and the manifest is committed, so a missing one is a broken checkout, not an empty start.
- The key-order canonicalization in `Dotfiles`. `json.load` then `json.dump` already keeps every key in order; the only job of those 12 lines was hiding that `upsert` inserted `dest` before `src`. `upsert` inserts `src` first now.
- The `Formatter` subclass. It only passed `max_help_position=30`, which a lambda does in place. Help output is byte-identical for every subcommand.
- `Dotfiles.show()`. `hal link` and `hal unlink` dumped the whole manifest after every change. `git diff dotfiles/hal_dotfiles.json` shows the delta, and `unlink` prints a `mv` line like `link` does.
- Small ones: `separators=(",", ": ")` on the JSON dumps (the default once `indent` is set), the `is_symlink() or exists()` guard that `unlink(missing_ok=True)` covers, and the "nothing to restore" guard for an empty manifest.

## Behavior changes to know about

- A non-glob entry whose src is missing and whose dest is outside both home and the repo now exits 1, instead of printing "not found" and moving on.
- A path refusal prints after the thread pool drains, and only the first unsafe entry is reported.
- `hal update` no longer prints `HAL: which ansible`, since no command runs for the lookup anymore.
- `hal update` no longer runs a separate `git fetch`.
- `hal copy` is gone as a command. Use `hal link` instead.
- A missing `hal_dotfiles.json` raises instead of silently starting an empty manifest.
- Entry keys are written back in the order they were loaded. Nothing reorders a hand-edited entry anymore.
- `hal link` and `hal unlink` no longer print the manifest. `unlink` prints the `mv` it did.

Verified old versus new under the stock 3.9.6 interpreter on a fixture tree, up to the `hal copy` removal: output, resulting tree, and manifest match. The 5 cleanup commits after it change output on purpose (no manifest dump), so they were checked separately. Help output is byte-identical per subcommand, `save()` reproduces the committed manifest byte for byte, and `make hal-completion` is a no-op. 202 tests pass. The 4 that went pinned lazy loading, the missing-manifest fallback, and key reordering.

